### PR TITLE
docs(start-here,core-concepts,development,import-models): add configuration and  development content

### DIFF
--- a/docs.config.tsx
+++ b/docs.config.tsx
@@ -116,6 +116,16 @@ export const SIDEBAR: Sidebar = {
           },
         ],
       },
+      {
+        text: "Development",
+        collapsible: true,
+        items: [
+          {
+            text: "Local development",
+            link: "/docs/development/local-development",
+          },
+        ],
+      },
     ],
   },
   rightSidebar: {

--- a/src/pages/docs/core-concepts/cv-task.mdx
+++ b/src/pages/docs/core-concepts/cv-task.mdx
@@ -31,9 +31,7 @@ At the moment, VDP defines the data interface for popular CV Tasks:
 - _Keypoint detection_ - detect and localize multiple keypoints of objects in images
 - The list is growing ... 🌱
 
-Each CV task is described in depth in the respective section below. 
-
-If you'd like to **ask for a new model definition**, you can create a topic in [Discussions](https://github.com/instill-ai/vdp/discussions), or request it in the **#vdp** channel on [Discord](https://discord.gg/sevxWsqpGh).
+Each CV task is described in depth in the respective section below. If you'd like to ask for a new task, please start a new discussion on [GitHub](https://github.com/instill-ai/vdp/discussions), or request it in the #vdp channel of our [community](https://discord.gg/sevxWsqpGh).
 
 ### How to standardise
 

--- a/src/pages/docs/core-concepts/overview.mdx
+++ b/src/pages/docs/core-concepts/overview.mdx
@@ -69,3 +69,4 @@ The same interface definitions are used for both REST (via [gRPC-Gateway](https:
 - Protocol Buffers over gRPC
 
 The interface definitions are maintained in [protobufs](https://github.com/instill-ai/protobufs) with auto-generated Go codes in [protogen-go](https://github.com/instill-ai/protogen-go) and Python code in [protogen-python](https://github.com/instill-ai/protogen-python).
+The genuine protobuf documentation can be found in our [Buf Scheme Registry (BSR)](https://buf.build/instill-ai/protobufs).

--- a/src/pages/docs/development/local-development.mdx
+++ b/src/pages/docs/development/local-development.mdx
@@ -1,0 +1,102 @@
+import { DocsLayout } from "@/components/docs";
+export const meta = {
+  title: "Local development",
+  lang: "en-US",
+  draft: false,
+  description:
+    "Learn about how to set up the open-source visual data ETL tool VDP https://github.com/instill-ai/vdp",
+  date: "",
+};
+
+export default ({ children }) => (
+  <DocsLayout meta={meta}>{children}</DocsLayout>
+);
+
+VDP is built with the microservice architecture. To develop each service independently, we assign [profiles](https://docs.docker.com/compose/profiles) to each service in the [`docker-compose-dev.yml`](https://github.com/instill-ai/vdp/blob/main/docker-compose-dev.yml) file in VDP.
+This allows us to selectively enabling services for various usages, e.g., debugging or development.
+
+> Services are associated with profiles through the `profiles` attribute, which takes an array of profile names.
+> A service will be started only if one of its profile names is activated. A service without `profiles` will always be started.
+
+VDP assigns five different profile names:
+
+- `console` - start all the dependent services for `console`
+- `mgmt` - start all the dependent services for `mgmt-backend`
+- `connector` - start all the dependent services for `connector-backend`
+- `model` - start all the dependent services for `model-backend`
+- `pipeline` - start all the dependent services for `pipeline-backend`
+- `all` - start all services
+
+Use one of the profile name to develop the corresponding service:
+
+```bash
+# In VDP project
+make build PROFILE=<valid-profile-name>
+make dev PROFILE=<valid-profile-name>
+```
+
+The following guideline shows detailed guideline about how to develop the `connector-backend`.
+
+### Start dependent VDP services for `connector-backend`
+
+On the local machine, clone `vdp` repository in your workspace, move to the repository folder, and launch all dependent microservices:
+
+```bash
+# Clone VDP project
+cd <your-workspace>
+git clone https://github.com/instill-ai/vdp.git
+cd vdp
+
+# Use profile `connector` to launch all dependent services for `connector-backend`
+make build PROFILE=connector
+make dev PROFILE=connector
+```
+
+### Run dev `connector-backend`
+
+Clone `connector-backend` repository in your workspace and move to the repository folder:
+
+```bash
+cd <your-workspace>
+git clone https://github.com/instill-ai/connector-backend.git
+cd connector-backend
+```
+
+**Build & run the dev image**
+
+```bash
+make build
+make dev
+```
+
+Now, you have the Go project set up in the container, in which you can compile and run the binaries together with the integration test in each container shell.
+
+**Start the `connector-backend` server**
+
+```bash
+docker exec -it connector-backend /bin/bash
+go run ./cmd/migration
+go run ./cmd/init
+go run ./cmd/main
+```
+
+**Start the Temporal worker**
+
+```bash
+docker exec -it connector-backend /bin/bash
+go run ./cmd/worker
+```
+
+**Run the integration test**
+During development, you can run the integration test to make sure the updated `connector-backend` works as intended:
+
+```bash
+docker exec -it connector-backend /bin/bash
+make integration-test
+```
+
+### Stop the dev container
+
+```bash
+make stop
+```

--- a/src/pages/docs/development/local-development.mdx
+++ b/src/pages/docs/development/local-development.mdx
@@ -15,7 +15,7 @@ export default ({ children }) => (
 VDP is built with the microservice architecture. To develop each service independently, we assign [profiles](https://docs.docker.com/compose/profiles) to each service in the [`docker-compose-dev.yml`](https://github.com/instill-ai/vdp/blob/main/docker-compose-dev.yml) file in VDP.
 This allows us to selectively enabling services for various usages, e.g., debugging or development.
 
-> Services are associated with profiles through the `profiles` attribute, which takes an array of profile names.
+> 📔 Services are associated with profiles through the `profiles` attribute, which takes an array of profile names.
 > A service will be started only if one of its profile names is activated. A service without `profiles` will always be started.
 
 VDP assigns five different profile names:

--- a/src/pages/docs/import-models/overview.mdx
+++ b/src/pages/docs/import-models/overview.mdx
@@ -26,4 +26,4 @@ Currently, VDP supports importing models using the following `model definitions`
 - [Local](/docs/import-models/local)
 - The list is growing ... 🌱
 
-If you'd like to **ask for a new model definition**, you can create a topic in [Discussions](https://github.com/instill-ai/vdp/discussions), or request it in the **#vdp** channel on [Discord](https://discord.gg/sevxWsqpGh).
+If you'd like to **ask for a new model definition**, you can start a new discussion on [GitHub](https://github.com/instill-ai/vdp/discussions), or request it in the #vdp channel of our [community](https://discord.gg/sevxWsqpGh).

--- a/src/pages/docs/start-here/configuration.mdx
+++ b/src/pages/docs/start-here/configuration.mdx
@@ -12,6 +12,119 @@ export default ({ children }) => (
   <DocsLayout meta={meta}>{children}</DocsLayout>
 );
 
-## Anonymized Usage Collection
+VDP automatically load a [`.env`](https://github.com/instill-ai/vdp/blob/main/.env) file that contains key/value pairs defining required environment variables.
+You can customize the file based on your configuration.
 
-https://dvc.org/doc/user-guide/analytics
+## Configuring services
+
+VDP services uses [Koanf](https://github.com/knadh/koanf) library for configuration. It supports loading configuration from multiple sources and make it available to the service.
+To override the default configuration file, you can set the corresponding environment variable in the [Compose](https://github.com/instill-ai/vdp/blob/main/docker-compose.yml) file in VDP.
+All configuration environment variables for each service are prefixed with `CFG_`.
+
+Read the default configuration files for a full overview of all supported configuration options of each service:
+[`mgmt-backend`](https://github.com/instill-ai/mgmt-backend/blob/main/config/config.yaml),
+[`connector-backend`](https://github.com/instill-ai/connector-backend/blob/main/config/config.yaml),
+[`model-backend`](https://github.com/instill-ai/model-backend/blob/main/config/config.yaml) and
+[`pipeline-backend`](https://github.com/instill-ai/pipeline-backend/blob/main/config/config.yaml).
+
+**Configuring VDP service version**
+
+Set the environment variable for a specific service to determine which version to use in VDP.
+
+```make .env
+# Set the version of individual VDP service
+CONSOLE_VERSION=<console-version>
+MGMT_BACKEND_VERSION=<mgmt-backend-version>
+CONNECTOR_BACKEND_VERSION=<connector-backend-version>
+MODEL_BACKEND_VERSION=<model-backend-version>
+PIPELINE_BACKEND_VERSION=<pipeline-backend-version>
+
+# Set the version of 3rd party tools
+TRITON_SERVER_VERSION=<triton-server-version>
+REDIS_VERSION=<redis-version>
+POSTGRESQL_VERSION=<postgresql-version>
+TEMPORAL_VERSION=<temporal-version>
+TEMPORAL_UI_VERSION=<temporal-ui-version>
+```
+
+The combination of default versions in `.env` file is fully tested for compatibility.
+Unless you are debugging and testing, updating the default versions in `env` file is discouraged.
+
+**Configuring VDP domain**
+
+Set the domain name to access VDP by overriding the environment variable `DOMAIN`:
+
+```make .env
+DOMAIN=<domain-name-to-access-vdp>
+```
+
+Without setting `DOMAIN`, the default domain is `localhost`.
+
+## Anonymised Usage Collection
+
+To help us better understand how VDP is used and can be improved, VDP collects and reports _Anonymised_ usage statistics.
+
+### What data is collected
+
+> 📔 **We value your privacy.** So, we went for the annoymous data and selected a set of details to share from your VDP instance that would give us insights about how to improve VDP without being invasive.
+
+When a new VDP is running, the usage client in services including `mgmt-backend`, `connector-backend`, `model-backend` and `pipeline-backend` in VDP will ask for a new session, respectively.
+Our usage server returns a token used for future reporting.
+For each session, we collect [`Session`](https://github.com/instill-ai/protobufs/blob/01d024a562d083f896b840acc6153f3cf1b4e858/vdp/usage/v1alpha/usage.proto#L15-L66) data including some basic information about the service and the system details the service is running on:
+
+- name of the service to collect data from, e.g., `SERVICE_CONNECTOR` for `connector-backend`
+- edition of the service to identify the deployment, e.g., `local-ce` for local open-source deployment
+- version of the service, e.g., `0.5.0-alpha`
+- architecture of the system the service is running on, e.g., `amd64`
+- operating system the service is running on, e.g., `linux`
+- uptime in seconds to identify the rough life span of the service
+
+Each session is assigned with a random UUID for tracking and identification.
+Then, each session will collect and send its own [`SessionReport`](https://github.com/instill-ai/protobufs/blob/01d024a562d083f896b840acc6153f3cf1b4e858/vdp/usage/v1alpha/usage.proto#L153-L175) data every one hour:
+
+- [`MgmtUsageData`](https://github.com/instill-ai/protobufs/blob/01d024a562d083f896b840acc6153f3cf1b4e858/vdp/usage/v1alpha/usage.proto#L68-L72) reports data for `mgmt-backend` session
+  - information of the [onboarded User](/docs/start-here/build-your-first-pipeline#onboarding)
+- [`ConnectorUsageData`](https://github.com/instill-ai/protobufs/blob/01d024a562d083f896b840acc6153f3cf1b4e858/vdp/usage/v1alpha/usage.proto#L74-L103) reports data for `connector-backend` session of the onboarded User
+  - UUID of the onboarded User
+  - number of _connected_ or _disconnected_ Sources
+  - number of _connected_ or _disconnected_ Destinations
+  - array of `SourceConenctorDefinition` of the Sources
+  - array of `DestinationConnectorDefinition` of the Destinations
+- [`ModelUsageData`](https://github.com/instill-ai/protobufs/blob/01d024a562d083f896b840acc6153f3cf1b4e858/vdp/usage/v1alpha/usage.proto#L105-L130) reports data for `model-backend` session of the onboarded User
+  - UUID of the onboarded User
+  - number of Models that have at least one _online_ Model Instance or have no _online_ Model Instances
+  - number of _online_ and _offline_ Model Instances
+  - array of `ModelDefinition` of the Models
+  - array of CV Tasks of the Model Instances
+  - number of processed images for testing models
+- [`PipelineUsageData`](https://github.com/instill-ai/protobufs/blob/01d024a562d083f896b840acc6153f3cf1b4e858/vdp/usage/v1alpha/usage.proto#L132-L151) reports data for `pipeline-backend` session of the onboarded User
+  - UUID of the onboarded User
+  - number of _active_ and _inactive_ Pipelines
+  - number of `SYNC` and `ASYNC` Pipelines
+  - number of images processed by the Pipelines
+
+You can check the full usage data structs in [protobufs](https://github.com/instill-ai/protobufs/blob/main/vdp/usage/v1alpha/usage.proto).
+These data does not allow us to track Personal Data but enables us to measure session counts and usage statistics.
+
+### Implementation
+
+The anonymous usage report client library is open-source in [`usage-client`](https://github.com/instill-ai/usage-client).
+To limit risk exposure, we keep the usage server implementation private for now.
+In summary, the Session data and SessionReport sent from each session get updated in the usage server.
+
+Additionally, The frontend Console sends event data to [Amplitude](https://amplitude.com).
+
+### Opting out
+
+DVC usage collection helps the entire community, we really appreciate if you can leave it on.
+However, if you want to opt out, you can disable it by overriding the `.env` file:
+
+```make .env
+DISABLEUSAGE=true
+```
+
+This will disable the VDP usage collection for the entire project.
+
+## Acknowledgements
+
+Our Anonymised usage collection were inspired by KrakenD's [How we built our telemetry service](https://www.krakend.io/blog/building-a-telemetry-service/) and would love to acknowledge that their design has helped us to bootstrap our usage collection project.

--- a/src/pages/docs/start-here/faq.mdx
+++ b/src/pages/docs/start-here/faq.mdx
@@ -21,15 +21,16 @@ This page curates a list of frequently asked questions from our users, friends, 
 
 Modern data stack misses unstructured visual data processing.
 
-It is non-trivial to process unstructured visual data though. 
-We used to suffer enough in devising our own deep learning computer vision models, putting the models in production, running the day-to-day operation, and endlessly building the peripheral MLOps tools to keep the production AI performance consistent. 
-All these happened in-house and were non-scalable. 
+It is non-trivial to process unstructured visual data though.
+We used to suffer enough in devising our own deep learning computer vision models, putting the models in production, running the day-to-day operation, and endlessly building the peripheral MLOps tools to keep the production AI performance consistent.
+All these happened in-house and were non-scalable.
 
 There must be a better way, and **Visual Data Preparation (VDP)** is the answer.
 
 To prevail Vision AI and to make it accessible to everyone, the point is not merely the algorithms (i.e., the computer vision models) but an infrastructure tooling to connect the value of the algorithms end-to-end with the modern data stack.
 
 You can find more detailed narrative in our blog article [Why Instill AI exists](https://blog.instill.tech/why-instill-ai-exists) and [Missing piece in modern data stack: visual data preparation](https://blog.instill.tech/visual-data-preparation).
+
 </details>
 
 <details>
@@ -40,10 +41,10 @@ We have in-depth experiences in developing and maintaining a Vision AI system.
 
 Before we started to build VDP, we had fought with streaming large volume data (billions of images a day!) to automate vision tasks using deep learning-based computer vision models, sweating blood to build everything from scratch.
 
-We have learned that model serving for an effective end-to-end data flow concerns not only **high throughput** and **low latency** but also **cost effectiveness**. These criteria are non-trivial to achieve altogether. 
+We have learned that model serving for an effective end-to-end data flow concerns not only **high throughput** and **low latency** but also **cost effectiveness**. These criteria are non-trivial to achieve altogether.
 In the end, we had successfully built a battle-proven Vision AI system in-house and have the system run in production for years.
 
-What we had built can actually be modularised into working components to benefit a broader spectrum of vision tasks and industry sectors. 
+What we had built can actually be modularised into working components to benefit a broader spectrum of vision tasks and industry sectors.
 We believe it's time to apply our experiences to make Vision AI more accessible to everyone especially the data industry.
 
 In spite of all that, VDP is an open-source project. Everyone is more than welcome to contribute to VDP in any forms. Please refer to the [Contribution](../start-here/getting-started#contribution) section.
@@ -68,7 +69,6 @@ If you are interested in the hosting service of VDP, we've started signing up us
 
 </details>
 
-
 <details>
 <summary>**How do you make money?**</summary>
 
@@ -83,17 +83,17 @@ If you are interested in the hosting service of VDP, we've started signing up us
 <details>
 <summary>**VDP vs. Google/Amazon/etc.**</summary>
 
-Amazon Rekognition and Google Vision AI are off-the-shelf Vision AI API services using pre-trained models. If the pre-trained models do not work for your dataset, the APIs are useless for you. 
+Amazon Rekognition and Google Vision AI are off-the-shelf Vision AI API services using pre-trained models. If the pre-trained models do not work for your dataset, the APIs are useless for you.
 
 To make up the deficiency, Amazon SageMaker and Google Vertex AI alike cloud services offer general-purpose machine learning platform-as-a-service (MLPaaS) which focus on model generation for general machine learning problems.
 
-
 In contrast, VDP focuses on unstructured visual data ETL, in which the goal is to streamline the ETL pipeline components to enable the modern data stack to tap on the value of the unstructured visual data.
 
-In addition, choosing Google or Amazon alike means choosing a cloud vendor you prefer to be locked in. VDP, on the other hand, is vendor lock-in free. 
+In addition, choosing Google or Amazon alike means choosing a cloud vendor you prefer to be locked in. VDP, on the other hand, is vendor lock-in free.
 It is open-source and an API-first open platform. You can self-host VDP in AWS, GCP, or on-premise, or simply subscribe Instill Cloud to start using VDP in a snap.
 
-Last but not least, Instill Cloud offers one order of magnitude lower pay-as-you-go inference price, compared with those major cloud vendors. 
+Last but not least, Instill Cloud offers one order of magnitude lower pay-as-you-go inference price, compared with those major cloud vendors.
+
 </details>
 
 <details>
@@ -101,19 +101,20 @@ Last but not least, Instill Cloud offers one order of magnitude lower pay-as-you
 
 VDP is not a PaaS solution! VDP aims to integrate with the modern data stack for unstructured visual data ETL.
 
-To the best of our knowledge, these solutions either providing Vision AI API SaaS or Vision AI model generation PaaS. 
+To the best of our knowledge, these solutions either providing Vision AI API SaaS or Vision AI model generation PaaS.
 
-While effective computer vision models are crucial to transform image and video data, model generation is in fact a task orthogonal to the VDP pipeline. 
-The design principle of VDP is to make the use of models as flexible as possible. 
-VDP users can hence freely use their familiar ways to generate models and can import the generated model into a VDP pipeline easily. 
+While effective computer vision models are crucial to transform image and video data, model generation is in fact a task orthogonal to the VDP pipeline.
+The design principle of VDP is to make the use of models as flexible as possible.
+VDP users can hence freely use their familiar ways to generate models and can import the generated model into a VDP pipeline easily.
 
 Find out the supported model sources to import in [Import Models](../import-models/overview) section.
+
 </details>
 
 <details>
 <summary>**VDP vs. BentoML/TorchServe/TensorFlow Serving/Cortex/Cog/etc.**</summary>
 
-VDP is not just a model serving framework! Nonetheless, model serving is a core component in a VDP pipeline. 
+VDP is not just a model serving framework! Nonetheless, model serving is a core component in a VDP pipeline.
 
 See [Why is Triton Inference Server adopted?](#why-triton) for further detailed answer about model serving.
 
@@ -133,9 +134,9 @@ Nonetheless, VDP is API-first and cloud-native. You can use cURL or the protobuf
 <details>
 <summary>**What design principles does VDP adopt?**</summary>
 
-- [Microservice](https://en.wikipedia.org/wiki/Microservices) architecture makes VDP to be extensible, flexible and reusable for scenarios where new components are constantly added in VDP. 
-The overall microservice system can be also very efficient at scaling phase to scale each backend instances based on their individual workload. 
-For example. the `connector-backend` might be way less busy compared with the `model-backend` in a `SYNC` VDP pipeline.
+- [Microservice](https://en.wikipedia.org/wiki/Microservices) architecture makes VDP to be extensible, flexible and reusable for scenarios where new components are constantly added in VDP.
+  The overall microservice system can be also very efficient at scaling phase to scale each backend instances based on their individual workload.
+  For example. the `connector-backend` might be way less busy compared with the `model-backend` in a `SYNC` VDP pipeline.
 
 - [IDEALS](https://www.infoq.com/articles/microservices-design-ideals) (**I**nterface segregation, **D**eployability, **E**vent-driven, **A**vailability over consistency, **L**oose coupling, and **S**ingle responsibility) design principle sets a rigorous framework when there comes to any VDP design questions in our day-to-day development.
 
@@ -143,7 +144,7 @@ For example. the `connector-backend` might be way less busy compared with the `m
 
 - [The twelve-factor methodology](https://12factor.net) provides a down-to-earth guideline for the development and deployment of VDP components.
 
-Building an effective and efficient machine learning product requires implementing the cutting-edge best practices of MLOps. 
+Building an effective and efficient machine learning product requires implementing the cutting-edge best practices of MLOps.
 There are many essential components involved in the MLOps cycle, and notably, these components are still evolving.
 
 We believe tooling development in AI and Data industry is marching toward a completely modularisation future, meaning that components in MLOps need to take into account flexibility, extensibility and composability as the first-class citizen as far as the design principle goes.
@@ -156,9 +157,9 @@ We believe tooling development in AI and Data industry is marching toward a comp
 
 There are many great model serving frameworks out there available for production-level model inference — TorchServe, TensorFlow Serving, BentoML and Cortex just to name a few.
 
-VDP is highly opinionated in inference performance, as we are keen to achieve both high-throughput and low-latency at the same time, to make VDP cost-effective for our users. 
+VDP is highly opinionated in inference performance, as we are keen to achieve both high-throughput and low-latency at the same time, to make VDP cost-effective for the users.
 
-Computer vision algorithms can benefit from parallelism by nature, because all the pixels/voxels imagined in one 2D/3D image can share the same computing operations. 
+Computer vision algorithms can benefit from parallelism by nature, since the bunch of pixels/voxels imagined in a 2D/3D image essentially share the same computing operations.
 We were therefore looking into the highest performant GPU model serving framework to serve in a VDP pipeline.
 Triton Inference Server provides a native way to make the most of NVIDIA GPU architecture (e.g., concurrency, scheduler, batcher) for multiple frameworks including TensorRT, PyTorch, TensorFlow, ONNX, Python and more.
 
@@ -166,17 +167,16 @@ We are continuously working on new features to help create and import a Triton-b
 
 </details>
 
-
 <details>
 <summary>**Why does VDP adopt Airbyte?**</summary>
 
-VDP needs to load the structured data transformed from [Model](../core-concepts/model) to [Destination](../core-concepts/connector#destination). 
+VDP needs to load the structured data transformed from [Model](../core-concepts/model) to [Destination](../core-concepts/connector#destination).
 Since structured data has gained overflowing love in the data industry, instead of reinventing the wheel, what makes more sense is to investigate the best way to plug VDP into the modern data stack for the subsequent structured data journey.
 
-Soon, Airbyte showed up on our radar. 
+Soon, Airbyte showed up on our radar.
 
-Airbyte has provided a good number of destination connectors for structured data. 
-In addition, the Airbyte Protocol provides a standardised interface to integrate with VDP. 
+Airbyte has provided a good number of destination connectors for structured data.
+In addition, the Airbyte Protocol provides a standardised interface to integrate with VDP.
 Last but not least, VDP loves open source. Airbyte is also open source and the community welcomes all sorts of possibilities with Airbyte.
 
 </details>
@@ -186,8 +186,8 @@ Last but not least, VDP loves open source. Airbyte is also open source and the c
 <details>
 <summary>**Why is the company named Instill AI?**</summary>
 
-We have been attempting to land Vision AI products ever since the surge of deep learning in 2014. 
-On the way, we have learned how challenging this can be. To build effective AI products, educate the market about the AI, and eventually see the AI products helping people in real life, 
+We have been attempting to land Vision AI products ever since the surge of deep learning in 2014.
+On the way, we have learned how challenging this can be. To build effective AI products, educate the market about the AI, and eventually see the AI products helping people in real life,
 it is fair to say that we, the whole industry, still have a long way to go.
 
 We are enthusiastic about being on the journey, to instill the Vision AI gradually to the industry.
@@ -195,11 +195,12 @@ We are enthusiastic about being on the journey, to instill the Vision AI gradual
 The name is also inspired by a Chinese poem "Delighting in Rain on a Spring Night (春夜喜雨)" by Du Fu (杜甫), particularly for reifying the word "instill":
 
 > 好雨知時節，當春乃發生。
-隨風潛入夜，潤物細無聲。
-野徑雲俱黑，江船火獨明。
-曉看紅濕處，花重錦官城。
+> 隨風潛入夜，潤物細無聲。
+> 野徑雲俱黑，江船火獨明。
+> 曉看紅濕處，花重錦官城。
 
-It's pretty hard to have this poem precisely translated in English, but anyway the main idea is to express how delightful when hard working finally pays off. 
+# It's pretty hard to have this poem precisely translated in English, but anyway the main idea is to express how delightful when hard working finally pays off.
+
 </details>
 
 <details>
@@ -208,7 +209,7 @@ It's pretty hard to have this poem precisely translated in English, but anyway t
 Our visual designer [Wen Chen](https://mrwenchen.com/about) has done a great job to embed Instill AI and the meaning of our effort into the logo.
 
 <p align="center">
-<img src="/docs-assets/start-here/why-logo.png" alt="logo" width="400"/>
+  <img src="/docs-assets/start-here/why-logo.png" alt="logo" width="400" />
 </p>
 
 </details>

--- a/src/pages/docs/start-here/getting-started.mdx
+++ b/src/pages/docs/start-here/getting-started.mdx
@@ -78,10 +78,10 @@ Jump right in
 
 ## Contribution
 
-👐 We love contribution to VDP in any forms:
+👐 We love contribution to [VDP](https://github.com/instill-ai/vdp) in any forms:
 
-- Please refer to the [configuration](configuration) for local development. 
-- Please open a topic in the repository [Discussions](https://github.com/instill-ai/vdp/discussions) for any feature requests.
+- Please refer to the [guideline](/docs/development/local-development) for local development
+- Please open a topic in the repository [Discussions](https://github.com/instill-ai/vdp/discussions) for any feature requests
 - Please open issues for bug report in the repository
   - [vdp](https://github.com/instill-ai/vdp) for general issues;
   - [pipeline-backend](https://github.com/instill-ai/pipeline-backend), [connector-backend](https://github.com/instill-ai/connector-backend), [model-backend](https://github.com/instill-ai/model-backend), [mgmt-backend](https://github.com/instill-ai/mgmt-backend), [console](https://github.com/instill-ai/console), etc., for specific issues.


### PR DESCRIPTION
Because

- we're iterating the documentation

This commit

- add contents in `start-here/configuration`
- add `development` section
- other small documentation fixes