### PR TITLE
docs(core-concepts): add connector release stage

### DIFF
--- a/src/pages/docs/core-concepts/connector.mdx
+++ b/src/pages/docs/core-concepts/connector.mdx
@@ -14,6 +14,8 @@ export default ({ children }) => (
 
 At the two ends of a VDP pipeline, there are source connector (i.e., the E in ETL) and destination connector (i.e., the L in ETL).
 
+## Definition
+
 ## Source
 
 A source connector is in charge of ingesting unstructured visual data into **Pipeline**.
@@ -35,3 +37,21 @@ Specifically, to trigger a destination connector's container [`write`](https://d
 As far as [Airbyte connections and sync modes](https://docs.airbyte.com/understanding-airbyte/connections) are concerned, VDP currently supports `full_refresh` sync mode and `append` destination sync mode for an `ASYNC` pipeline.
 
 VDP currently does not support Airbyte's [Namespaces](https://docs.airbyte.com/understanding-airbyte/namespaces).
+
+## State
+
+## Release stage
+
+#### Source connectors
+
+Instill AI develops and maintains source connectors. We use release stage below to indicate a source connector's readiness:
+
+| Stage                   | Description                                                                                                                                                                                                                                                            |
+| :---------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Alpha**               | An alpha source connector indicates the connector is under development and Instill AI is collecting its early feedback and issues reported by early adopters. We strongly discourage using alpha source connectors for production.                                     |
+| **Beta**                | A beta source connector is considered stable and reliable with no further backwards incompatible changes but has not been validated by a broader group of users. We expect to find and fix a few issues and bugs in the release before it is ready for the next stage. |
+| **Generally Available** | A generally available source connector has been thoroughly tested in the battlefield and is ready for use in a production environment. Its documentation is considered sufficient to support widespread adoption.                                                      |
+
+#### Destination connectors
+
+Destination connectors are developed and maintained by Airbyte community, where the release stage of each Airbyte destination connector is reported [here](https://docs.airbyte.com/integrations/#destinations).

--- a/src/pages/docs/core-concepts/connector.mdx
+++ b/src/pages/docs/core-concepts/connector.mdx
@@ -12,13 +12,13 @@ export default ({ children }) => (
   <DocsLayout meta={meta}>{children}</DocsLayout>
 );
 
-At the two ends of a VDP pipeline, there are source connector (i.e., the E in ETL) and destination connector (i.e., the L in ETL).
+At the two ends of a VDP pipeline, there are **Source** component (i.e., the E in ETL) and **Destination** component (i.e., the L in ETL).
 
 ## Definition
 
 ## Source
 
-A source connector is in charge of ingesting unstructured visual data into **Pipeline**.
+A **Source** component is a data connector in charge of ingesting unstructured visual data into **Pipeline**.
 
 VDP supports HTTP and gRPC source connector for both `SYNC` and `ASYNC` pipelines.
 
@@ -26,7 +26,7 @@ Source connectors for the pipeline [`FETCH`](core-concepts/pipeline#fetch-mode) 
 
 ## Destination
 
-A destination connector is to write the standardised CV Task output from **Model** to the destination data warehouse or notification.
+A **Destination** component is a data connector to write the standardised CV Task output from **Model** to the destination data warehouse or notification.
 
 VDP supports HTTP and gRPC destination connector for the `SYNC` pipeline.
 
@@ -42,7 +42,7 @@ VDP currently does not support Airbyte's [Namespaces](https://docs.airbyte.com/u
 
 ## Release stage
 
-#### Source connectors
+#### Source release stage
 
 Instill AI develops and maintains source connectors. We use release stage below to indicate a source connector's readiness:
 
@@ -52,6 +52,6 @@ Instill AI develops and maintains source connectors. We use release stage below 
 | **Beta**                | A beta source connector is considered stable and reliable with no further backwards incompatible changes but has not been validated by a broader group of users. We expect to find and fix a few issues and bugs in the release before it is ready for the next stage. |
 | **Generally Available** | A generally available source connector has been thoroughly tested in the battlefield and is ready for use in a production environment. Its documentation is considered sufficient to support widespread adoption.                                                      |
 
-#### Destination connectors
+#### Destination release stage
 
 Destination connectors are developed and maintained by Airbyte community, where the release stage of each Airbyte destination connector is reported [here](https://docs.airbyte.com/integrations/#destinations).

--- a/src/pages/docs/core-concepts/pipeline.mdx
+++ b/src/pages/docs/core-concepts/pipeline.mdx
@@ -33,7 +33,9 @@ A `recipe` describes a pipeline resource consisting of:
 
 Depending on the use case, the user can create a pipeline in `SYNC`, `ASYNC`, or `FETCH` mode. The pipeline mode is determined by the combination of selected source and destination. Continue to read for more details.
 
-## SYNC mode
+## Mode
+
+#### `SYNC` mode
 
 A pipeline in the `SYNC` mode responds to a request synchronously. The result is sent back to the user right after the data is processed by **Model**. This mode is for real-time inference where low latency is of concern.
 The request flow when triggering a `SYNC` pipeline is shown below:
@@ -42,7 +44,7 @@ The request flow when triggering a `SYNC` pipeline is shown below:
   <img src="/docs-assets/core-concepts/sync.svg" alt="SYNC pipeline mode" />
 </p>
 
-To create a `SYNC` pipeline, both source and destination needs to be configured with the same type of protocol. VDP supports HTTP and gRPC for a `SYNC` pipeline.
+To create a `SYNC` pipeline, both source and destination needs to be configured with the same protocol type. VDP supports HTTP and gRPC for a `SYNC` pipeline.
 
 For example, this `recipe` defines a gRPC `SYNC` pipeline for real-time YOLOv7 inference:
 
@@ -54,7 +56,7 @@ For example, this `recipe` defines a gRPC `SYNC` pipeline for real-time YOLOv7 i
 }
 ```
 
-## ASYNC mode
+#### `ASYNC` mode
 
 A pipeline in the `ASYNC` mode performs asynchronous workload. The user triggers the pipeline with an asynchronous request and only receives an acknowledged response.
 Once the data has been processed by **Model**, the result is sent to the data destination. This mode is for use cases that do not require inference results immediately.
@@ -75,7 +77,7 @@ For example, this `recipe` defines an`ASYNC` pipeline to detect images by YOLOv7
 }
 ```
 
-## FETCH mode
+#### `FETCH` mode (coming soon)
 
 A pipeline in the `FETCH` mode performs scheduled workload to regularly fetch data from the **Source** to send to **Model** for inference and write to destination in the end.
 
@@ -83,4 +85,4 @@ A pipeline in the `FETCH` mode performs scheduled workload to regularly fetch da
   <img src="/docs-assets/core-concepts/fetch.svg" alt="FETCH pipeline mode" />
 </p>
 
-`FETCH` mode support is coming soon.
+## State

--- a/src/pages/docs/start-here/faq.mdx
+++ b/src/pages/docs/start-here/faq.mdx
@@ -177,7 +177,7 @@ Soon, Airbyte showed up on our radar.
 
 Airbyte has provided a good number of destination connectors for structured data.
 In addition, the Airbyte Protocol provides a standardised interface to integrate with VDP.
-Last but not least, VDP loves open source. Airbyte is also open source and the community welcomes all sorts of possibilities with Airbyte.
+Last but not least, VDP loves open source. Airbyte is also open source and the community welcomes all sorts of possibilities.
 
 </details>
 


### PR DESCRIPTION
Because

- we are rapidly iterating the documentation

This commit

- add release stage in `core-concepts/connector`
- reword some places