### PR TITLE
docs(source-connectors,destination-connectors): add connector pages

### DIFF
--- a/docs.config.tsx
+++ b/docs.config.tsx
@@ -66,6 +66,7 @@ export const SIDEBAR: Sidebar = {
           { text: "Overview", link: "/docs/destination-connectors/overview" },
           { text: "HTTP", link: "/docs/destination-connectors/http" },
           { text: "gRPC", link: "/docs/destination-connectors/grpc" },
+          { text: "Airbyte", link: "/docs/destination-connectors/airbyte" },
         ],
       },
       {

--- a/src/pages/docs/destination-connectors/airbyte.mdx
+++ b/src/pages/docs/destination-connectors/airbyte.mdx
@@ -1,0 +1,26 @@
+import { DocsLayout } from "@/components/docs";
+export const meta = {
+  title: "Airbyte Destination Connectors",
+  lang: "en-US",
+  draft: false,
+  description: "Learn about how to set up Airbyte destination connectors for the open-source visual data ETL tool VDP https://github.com/instill-ai/vdp",
+  date: "",
+};
+
+export default ({ children }) => (
+  <DocsLayout meta={meta}>{children}</DocsLayout>
+);
+
+## Description
+
+An Airbyte destination connector paired with any source connector defines an `ASYNC` or `FETCH` pipeline. 
+
+An Airbyte destination connector is in `CONNECTED` state only when its configuration is valid to connect with the destination. Otherwise, the state will be either `ERROR` or `UNSPECIFIED`.
+
+## Release stage
+
+Please refer to the Airbyte [Destinations Connector Catalog](https://docs.airbyte.com/integrations/#destinations) table.
+
+## Configuration
+
+Please refer to each Airbyte [Destinations](https://docs.airbyte.com/category/destinations) for configuration details.

--- a/src/pages/docs/destination-connectors/grpc.mdx
+++ b/src/pages/docs/destination-connectors/grpc.mdx
@@ -1,12 +1,29 @@
 import { DocsLayout } from "@/components/docs";
 export const meta = {
-  title: "Real-time Destination gRPC",
+  title: "gRPC Destination Connector",
   lang: "en-US",
-  draft: true,
-  description: "",
+  draft: false,
+  description:
+    "Learn about how to set up a gRPC destination connector for the open-source visual data ETL tool VDP https://github.com/instill-ai/vdp",
   date: "",
 };
 
 export default ({ children }) => (
   <DocsLayout meta={meta}>{children}</DocsLayout>
 );
+
+## Description
+
+A gRPC destination connector is for pairing with a gRPC source connector to set up a `SYNC` pipeline. 
+
+A gRPC destination connector is always in the `CONNECTED` state.
+
+## Release stage
+
+`Generally Available`
+
+## Configuration
+
+| Field | Type | Notes                                                                                                 |
+| :---- | :--- | :---------------------------------------------------------------------------------------------------- |
+| N/A   | N/A  | This connector doesn't take any configuration so the configuration field is an empty JSON object `{}` |

--- a/src/pages/docs/destination-connectors/http.mdx
+++ b/src/pages/docs/destination-connectors/http.mdx
@@ -1,12 +1,29 @@
 import { DocsLayout } from "@/components/docs";
 export const meta = {
-  title: "Real-time Destination HTTP",
+  title: "HTTP Destination Connector",
   lang: "en-US",
-  draft: true,
-  description: "",
+  draft: false,
+  description:
+    "Learn about how to set up a HTTP destination connector for the open-source visual data ETL tool VDP https://github.com/instill-ai/vdp",
   date: "",
 };
 
 export default ({ children }) => (
   <DocsLayout meta={meta}>{children}</DocsLayout>
 );
+
+## Description
+
+A HTTP destination connector is for pairing with a HTTP source connector to set up a `SYNC` pipeline. 
+
+A HTTP destination connector is always in the `CONNECTED` state.
+
+## Release stage
+
+`Generally Available`
+
+## Configuration
+
+| Field | Type | Notes                                                                                                 |
+| :---- | :--- | :---------------------------------------------------------------------------------------------------- |
+| N/A   | N/A  | This connector doesn't take any configuration so the configuration field is an empty JSON object `{}` |

--- a/src/pages/docs/destination-connectors/overview.mdx
+++ b/src/pages/docs/destination-connectors/overview.mdx
@@ -11,3 +11,17 @@ export const meta = {
 export default ({ children }) => (
   <DocsLayout meta={meta}>{children}</DocsLayout>
 );
+
+A destination connector is to write the standardised **CV Task** output from **Model** to the destination data warehouse or notification.
+
+A destination connector in VDP is defined by [`DestinationConnectorDefinition`](https://github.com/instill-ai/protobufs/blob/main/vdp/connector/v1alpha/connector_definition.proto#L126-L149) 
+which defines the basic properties of a source connector, of which the inner field [`connector_definition.spec.connection_specification`](https://github.com/instill-ai/protobufs/blob/main/vdp/connector/v1alpha/spec.proto#L43-L45) 
+defines the connector configuration JSON Schema.
+
+Currently, VDP supports source connectors:
+
+- [HTTP](/docs/source-connectors/http)
+- [gRPC](/docs/source-connectors/grpc)
+- [Airbyte Destination Connectors](/docs/source-connectors/airbyte-destination-connector)
+
+If you'd like to **ask for a new source connector**, you can create a topic in [Discussions](https://github.com/instill-ai/vdp/discussions), or request it in the **#vdp** channel on [Discord](https://discord.gg/sevxWsqpGh).

--- a/src/pages/docs/source-connectors/grpc.mdx
+++ b/src/pages/docs/source-connectors/grpc.mdx
@@ -1,12 +1,32 @@
 import { DocsLayout } from "@/components/docs";
 export const meta = {
-  title: "Real-time Source gRPC",
+  title: "gRPC Source Connector",
   lang: "en-US",
-  draft: true,
-  description: "",
+  draft: false,
+  description: "Learn about how to set up a gRPC source connector for the open-source visual data ETL tool VDP https://github.com/instill-ai/vdp",
   date: "",
 };
 
 export default ({ children }) => (
   <DocsLayout meta={meta}>{children}</DocsLayout>
 );
+
+## Description
+
+When a gRPC source connector is paired with a gRPC destination connector, the pipeline will be in the `SYNC` mode. 
+
+When a gRPC source connector is paired with an Airbyte connector, the pipeline will be in the `ASYNC` mode.
+
+An gRPC source connector cannot be paired with a HTTP destination connector.
+
+A gRPC source connector is always in the `CONNECTED` state.
+
+## Release stage
+
+`Generally Available`
+
+## Configuration
+
+| Field | Type | Notes                                                                                                 |
+| :---- | :--- | :---------------------------------------------------------------------------------------------------- |
+| N/A   | N/A  | This connector doesn't take any configuration so the configuration field is an empty JSON object `{}` |

--- a/src/pages/docs/source-connectors/http.mdx
+++ b/src/pages/docs/source-connectors/http.mdx
@@ -1,12 +1,33 @@
 import { DocsLayout } from "@/components/docs";
 export const meta = {
-  title: "Real-time Source HTTP",
+  title: "HTTP Source Connector",
   lang: "en-US",
-  draft: true,
-  description: "",
+  draft: false,
+  description:
+    "Learn about how to set up a HTTP source connector for the open-source visual data ETL tool VDP https://github.com/instill-ai/vdp",
   date: "",
 };
 
 export default ({ children }) => (
   <DocsLayout meta={meta}>{children}</DocsLayout>
 );
+
+## Description
+
+When a HTTP source connector is paired with a HTTP destination connector, the pipeline will be in the `SYNC` mode.
+
+When a HTTP source connector is paired with an Airbyte connector, the pipeline will be in the `ASYNC` mode.
+
+An HTTP source connector cannot be paired with a gRPC destination connector.
+
+A HTTP source connector is always in the `CONNECTED` state.
+
+## Release stage
+
+`Generally Available`
+
+## Configuration
+
+| Field | Type | Notes                                                                                                 |
+| :---- | :--- | :---------------------------------------------------------------------------------------------------- |
+| N/A   | N/A  | This connector doesn't take any configuration so the configuration field is an empty JSON object `{}` |

--- a/src/pages/docs/source-connectors/overview.mdx
+++ b/src/pages/docs/source-connectors/overview.mdx
@@ -11,3 +11,17 @@ export const meta = {
 export default ({ children }) => (
   <DocsLayout meta={meta}>{children}</DocsLayout>
 );
+
+A source connector is in charge of ingesting unstructured visual data into **Pipeline**.
+
+A source connector in VDP is defined by [`SourceConnectorDefinition`](https://github.com/instill-ai/protobufs/blob/main/vdp/connector/v1alpha/connector_definition.proto#L104-L124) 
+which defines the basic properties of a source connector, of which the inner field [`connector_definition.spec.connection_specification`](https://github.com/instill-ai/protobufs/blob/main/vdp/connector/v1alpha/spec.proto#L43-L45) 
+defines the connector configuration JSON Schema.
+
+Currently, VDP supports source connectors:
+
+- [HTTP](/docs/source-connectors/http)
+- [gRPC](/docs/source-connectors/grpc)
+- The list is growing ... 🌱
+
+If you'd like to **ask for a new source connector**, you can create a topic in [Discussions](https://github.com/instill-ai/vdp/discussions), or request it in the **#vdp** channel on [Discord](https://discord.gg/sevxWsqpGh).


### PR DESCRIPTION
Because

- we are rapidly iterating documentation

This commit

- add connector pages
