### PR TITLE
docs(source-connectors,destination-connectors): add setup guides

### DIFF
--- a/src/pages/docs/destination-connectors/airbyte.mdx
+++ b/src/pages/docs/destination-connectors/airbyte.mdx
@@ -3,7 +3,8 @@ export const meta = {
   title: "Airbyte Destination Connectors",
   lang: "en-US",
   draft: false,
-  description: "Learn about how to set up Airbyte destination connectors for the open-source visual data ETL tool VDP https://github.com/instill-ai/vdp",
+  description:
+    "Learn about how to set up Airbyte destination connectors for the open-source visual data ETL tool VDP https://github.com/instill-ai/vdp",
   date: "",
 };
 
@@ -13,9 +14,8 @@ export default ({ children }) => (
 
 ## Description
 
-An Airbyte destination connector paired with any source connector defines an `ASYNC` or `FETCH` pipeline. 
-
-An Airbyte destination connector is in `CONNECTED` state only when its configuration is valid to connect with the destination. Otherwise, the state will be either `ERROR` or `UNSPECIFIED`.
+- An Airbyte destination connector paired with any source connector defines an `ASYNC` or `FETCH` pipeline.
+- An Airbyte destination connector is in `CONNECTED` state only when its configuration is valid to connect with the destination. Otherwise, the state will be either `ERROR` or `UNSPECIFIED`.
 
 ## Release stage
 
@@ -24,3 +24,41 @@ Please refer to the Airbyte [Destinations Connector Catalog](https://docs.airbyt
 ## Configuration
 
 Please refer to each Airbyte [Destinations](https://docs.airbyte.com/category/destinations) for configuration details.
+
+### No-code setup
+
+To create an Airbyte destination connector (e.g., PostgreSQL):
+
+1. Go to the **Destination** page and click **Add new destination**
+2. Click the **Destination type** ▾ drop-down and choose **Postgres**
+3. Fill in the required fields
+4. [Optional] Give a short description in the **Description** field
+
+Now go to the **Destination** page, the corresponding PostgresSQL destination connector should be connected.
+
+### Low-code setup
+
+To create a gRPC destination connector:
+
+```bash cURL
+curl -X POST http://localhost:8082/v1alpha/destination-connectors -d '{
+  "id": "postgres-db",
+  "destination_connector_definition": "destination-connector-definitions/destination-postgres",
+  "connector": {
+    "description": "The PostgreSQL database in your basement",
+    "configuration": {
+      "host": <PostgreSQL host address>,
+      "port": <port>,
+      "database": <database>,
+      "schema": "public",
+      "username": <username>,
+      "password": <password>,
+      "ssl": false
+    }
+  }
+}'
+```
+
+, where `localhost:8082` is the URL of the `connector-backend`.
+
+For other operations, please refer to the [VDP Protobufs](https://buf.build/instill-ai/protobufs).

--- a/src/pages/docs/destination-connectors/grpc.mdx
+++ b/src/pages/docs/destination-connectors/grpc.mdx
@@ -14,9 +14,10 @@ export default ({ children }) => (
 
 ## Description
 
-A gRPC destination connector is for pairing with a gRPC source connector to set up a `SYNC` pipeline.
-
-A gRPC destination connector is always in the `CONNECTED` state.
+- A gRPC destination connector is for pairing with a gRPC source connector to set up a `SYNC` pipeline.
+- A gRPC destination connector is always in the `CONNECTED` state.
+- A gRPC destination connector's ID must be `destination-grpc`
+- A user account can set up only one gRPC destination connector.
 
 ## Release stage
 
@@ -27,3 +28,31 @@ A gRPC destination connector is always in the `CONNECTED` state.
 | Field | Type | Note                                                                                                  |
 | :---- | :--- | :---------------------------------------------------------------------------------------------------- |
 | N/A   | N/A  | This connector doesn't take any configuration so the configuration field is an empty JSON object `{}` |
+
+### No-code setup
+
+To create a gRPC destination connector:
+
+1. Go to the **Destination** page and click **Add new destination**
+2. Click the **Destination type** ▾ drop-down and choose **gRPC**
+3. [Optional] Give a short description in the **Description** field
+
+Now go to the **Destination** page, the corresponding gRPC destination connector should be connected.
+
+### Low-code setup
+
+To create a gRPC destination connector:
+
+```bash cURL
+curl -X POST http://localhost:8082/v1alpha/destination-connectors -d '{
+  "id": "destination-grpc",
+  "destination_connector_definition": "instill-ai/destination-grpc",
+  "connector": {
+    "configuration": {}
+  }
+}'
+```
+
+, where `localhost:8082` is the URL of the `connector-backend`.
+
+For other operations, please refer to the [VDP Protobufs](https://buf.build/instill-ai/protobufs).

--- a/src/pages/docs/destination-connectors/http.mdx
+++ b/src/pages/docs/destination-connectors/http.mdx
@@ -14,9 +14,10 @@ export default ({ children }) => (
 
 ## Description
 
-A HTTP destination connector is for pairing with a HTTP source connector to set up a `SYNC` pipeline.
-
-A HTTP destination connector is always in the `CONNECTED` state.
+- A HTTP destination connector is for pairing with a HTTP source connector to set up a `SYNC` pipeline.
+- A HTTP destination connector is always in the `CONNECTED` state.
+- A HTTP destination connector's ID must be `destination-http`
+- A user account can set up only one HTTP destination connector.
 
 ## Release stage
 
@@ -27,3 +28,31 @@ A HTTP destination connector is always in the `CONNECTED` state.
 | Field | Type | Note                                                                                                  |
 | :---- | :--- | :---------------------------------------------------------------------------------------------------- |
 | N/A   | N/A  | This connector doesn't take any configuration so the configuration field is an empty JSON object `{}` |
+
+### No-code setup
+
+To create a HTTP destination connector:
+
+1. Go to the **Destination** page and click **Add new destination**
+2. Click the **Destination type** ▾ drop-down and choose **HTTP**
+3. [Optional] Give a short description in the **Description** field
+
+Now go to the **Destination** page, the corresponding HTTP destination connector should be connected.
+
+### Low-code setup
+
+To create a HTTP destination connector:
+
+```bash cURL
+curl -X POST http://localhost:8082/v1alpha/destination-connectors -d '{
+  "id": "destination-http",
+  "destination_connector_definition": "instill-ai/destination-http",
+  "connector": {
+    "configuration": {}
+  }
+}'
+```
+
+, where `localhost:8082` is the URL of the `connector-backend`.
+
+For other operations, please refer to the [VDP Protobufs](https://buf.build/instill-ai/protobufs).

--- a/src/pages/docs/source-connectors/grpc.mdx
+++ b/src/pages/docs/source-connectors/grpc.mdx
@@ -14,13 +14,12 @@ export default ({ children }) => (
 
 ## Description
 
-When a gRPC source connector is paired with a gRPC destination connector, the pipeline will be in the `SYNC` mode.
-
-When a gRPC source connector is paired with an Airbyte connector, the pipeline will be in the `ASYNC` mode.
-
-An gRPC source connector cannot be paired with a HTTP destination connector.
-
-A gRPC source connector is always in the `CONNECTED` state.
+- When a gRPC source connector is paired with a gRPC destination connector, the pipeline will be in the `SYNC` mode.
+- When a gRPC source connector is paired with an Airbyte connector, the pipeline will be in the `ASYNC` mode.
+- An gRPC source connector cannot be paired with a HTTP destination connector.
+- A gRPC source connector is always in the `CONNECTED` state.
+- A gRPC source connector's ID must be `source-grpc`
+- A user account can set up only one gRPC source connector.
 
 ## Release stage
 
@@ -31,3 +30,31 @@ A gRPC source connector is always in the `CONNECTED` state.
 | Field | Type | Note                                                                                                  |
 | :---- | :--- | :---------------------------------------------------------------------------------------------------- |
 | N/A   | N/A  | This connector doesn't take any configuration so the configuration field is an empty JSON object `{}` |
+
+### No-code setup
+
+To create a gRPC source connector:
+
+1. Go to the **Source** page and click **Add new source**
+2. Click the **Source type** ▾ drop-down and choose **gRPC**
+3. [Optional] Give a short description in the **Description** field
+
+Now go to the **Source** page, the corresponding gRPC source connector should be connected.
+
+### Low-code setup
+
+To create a gRPC source connector:
+
+```bash cURL
+curl -X POST http://localhost:8082/v1alpha/source-connectors -d '{
+  "id": "source-grpc",
+  "source_connector_definition": "instill-ai/source-grpc",
+  "connector": {
+    "configuration": {}
+  }
+}'
+```
+
+, where `localhost:8082` is the URL of the `connector-backend`.
+
+For other operations, please refer to the [VDP Protobufs](https://buf.build/instill-ai/protobufs).

--- a/src/pages/docs/source-connectors/http.mdx
+++ b/src/pages/docs/source-connectors/http.mdx
@@ -14,13 +14,12 @@ export default ({ children }) => (
 
 ## Description
 
-When a HTTP source connector is paired with a HTTP destination connector, the pipeline will be in the `SYNC` mode.
-
-When a HTTP source connector is paired with an Airbyte connector, the pipeline will be in the `ASYNC` mode.
-
-An HTTP source connector cannot be paired with a gRPC destination connector.
-
-A HTTP source connector is always in the `CONNECTED` state.
+- When a HTTP source connector is paired with a HTTP destination connector, the pipeline will be in the `SYNC` mode.
+- When a HTTP source connector is paired with an Airbyte connector, the pipeline will be in the `ASYNC` mode.
+- An HTTP source connector cannot be paired with a gRPC destination connector.
+- A HTTP source connector is always in the `CONNECTED` state.
+- A HTTP source connector's ID must be `source-http`
+- A user account can set up only one HTTP source connector.
 
 ## Release stage
 
@@ -31,3 +30,31 @@ A HTTP source connector is always in the `CONNECTED` state.
 | Field | Type | Note                                                                                                  |
 | :---- | :--- | :---------------------------------------------------------------------------------------------------- |
 | N/A   | N/A  | This connector doesn't take any configuration so the configuration field is an empty JSON object `{}` |
+
+### No-code setup
+
+To create a HTTP source connector:
+
+1. Go to the **Source** page and click **Add new source**
+2. Click the **Source type** ▾ drop-down and choose **HTTP**
+3. [Optional] Give a short description in the **Description** field
+
+Now go to the **Source** page, the corresponding HTTP source connector should be connected.
+
+### Low-code setup
+
+To create a HTTP source connector:
+
+```bash cURL
+curl -X POST http://localhost:8082/v1alpha/source-connectors -d '{
+  "id": "source-http",
+  "source_connector_definition": "instill-ai/source-http",
+  "connector": {
+    "configuration": {}
+  }
+}'
+```
+
+, where `localhost:8082` is the URL of the `connector-backend`.
+
+For other operations, please refer to the [VDP Protobufs](https://buf.build/instill-ai/protobufs).

--- a/src/pages/docs/start-here/getting-started.mdx
+++ b/src/pages/docs/start-here/getting-started.mdx
@@ -78,7 +78,7 @@ Jump right in
 
 📔 Learn about how to [prepare](/docs/prepare-models/overview) and [import](/docs/import-models/overview) models
 
-📔 Explore the APIs of [protobufs](https://buf.build/instill-ai/protobufs) or [OpenAPI](http://localhost:3001) (after `make all` or `make doc`)
+📔 Explore the APIs of [Protobufs](https://buf.build/instill-ai/protobufs) or [OpenAPI](http://localhost:3001) (after `make all` or `make doc`)
 
 ## Contribution
 


### PR DESCRIPTION
Because

- we are rapidly iterating the documentation

This commit

- add connector setup guidelines
- reformat connector description
- fix typos
