### PR TITLE
docs: refine wording

### DIFF
--- a/src/pages/docs/core-concepts/model.mdx
+++ b/src/pages/docs/core-concepts/model.mdx
@@ -146,4 +146,4 @@ curl -X POST http://localhost:8083/v1alpha/models/{model-id}/instances/{instance
 
 </CH.Code>
 
-In which `http://localhost:8083` is the default URL of the VDP `model-backend`. `{model-id}` and `{instance-id}` correspond to the ID of model and model instance respectively.
+, in which `http://localhost:8083` is the `model-backend` default URL, and `{model-id}` and `{instance-id}` correspond to the ID of model and model instance respectively.

--- a/src/pages/docs/core-concepts/model.mdx
+++ b/src/pages/docs/core-concepts/model.mdx
@@ -146,4 +146,4 @@ curl -X POST http://localhost:8083/v1alpha/models/{model-id}/instances/{instance
 
 </CH.Code>
 
-, in which `http://localhost:8083` is the `model-backend` default URL, and `{model-id}` and `{instance-id}` correspond to the ID of model and model instance respectively.
+in which `http://localhost:8083` is the `model-backend` default URL, and `{model-id}` and `{instance-id}` correspond to the model and model instance ID respectively.

--- a/src/pages/docs/destination-connectors/airbyte.mdx
+++ b/src/pages/docs/destination-connectors/airbyte.mdx
@@ -59,6 +59,6 @@ curl -X POST http://localhost:8082/v1alpha/destination-connectors -d '{
 }'
 ```
 
-, where `localhost:8082` is the URL of the `connector-backend`.
+, where `localhost:8082` is the `connector-backend` URL.
 
 For other operations, please refer to the [VDP Protobufs](https://buf.build/instill-ai/protobufs).

--- a/src/pages/docs/destination-connectors/airbyte.mdx
+++ b/src/pages/docs/destination-connectors/airbyte.mdx
@@ -59,6 +59,6 @@ curl -X POST http://localhost:8082/v1alpha/destination-connectors -d '{
 }'
 ```
 
-, where `localhost:8082` is the `connector-backend` URL.
+where `localhost:8082` is the `connector-backend` default URL.
 
 For other operations, please refer to the [VDP Protobufs](https://buf.build/instill-ai/protobufs).

--- a/src/pages/docs/destination-connectors/grpc.mdx
+++ b/src/pages/docs/destination-connectors/grpc.mdx
@@ -53,6 +53,6 @@ curl -X POST http://localhost:8082/v1alpha/destination-connectors -d '{
 }'
 ```
 
-, where `localhost:8082` is the `connector-backend` URL.
+where `localhost:8082` is the `connector-backend` default URL.
 
 For other operations, please refer to the [VDP Protobufs](https://buf.build/instill-ai/protobufs).

--- a/src/pages/docs/destination-connectors/grpc.mdx
+++ b/src/pages/docs/destination-connectors/grpc.mdx
@@ -53,6 +53,6 @@ curl -X POST http://localhost:8082/v1alpha/destination-connectors -d '{
 }'
 ```
 
-, where `localhost:8082` is the URL of the `connector-backend`.
+, where `localhost:8082` is the `connector-backend` URL.
 
 For other operations, please refer to the [VDP Protobufs](https://buf.build/instill-ai/protobufs).

--- a/src/pages/docs/destination-connectors/http.mdx
+++ b/src/pages/docs/destination-connectors/http.mdx
@@ -53,6 +53,6 @@ curl -X POST http://localhost:8082/v1alpha/destination-connectors -d '{
 }'
 ```
 
-, where `localhost:8082` is the `connector-backend` URL.
+where `localhost:8082` is the `connector-backend` default URL.
 
 For other operations, please refer to the [VDP Protobufs](https://buf.build/instill-ai/protobufs).

--- a/src/pages/docs/destination-connectors/http.mdx
+++ b/src/pages/docs/destination-connectors/http.mdx
@@ -53,6 +53,6 @@ curl -X POST http://localhost:8082/v1alpha/destination-connectors -d '{
 }'
 ```
 
-, where `localhost:8082` is the URL of the `connector-backend`.
+, where `localhost:8082` is the `connector-backend` URL.
 
 For other operations, please refer to the [VDP Protobufs](https://buf.build/instill-ai/protobufs).

--- a/src/pages/docs/development/setup-local-development.mdx
+++ b/src/pages/docs/development/setup-local-development.mdx
@@ -44,8 +44,7 @@ On the local machine, clone `vdp` repository in your workspace, move to the repo
 ```shellscript
 # Clone VDP project
 cd <your-workspace>
-git clone https://github.com/instill-ai/vdp.git
-cd vdp
+git clone https://github.com/instill-ai/vdp.git && cd vdp
 
 # Use profile `connector` to launch all dependent services for `connector-backend`
 make build PROFILE=connector

--- a/src/pages/docs/import-models/artivc.mdx
+++ b/src/pages/docs/import-models/artivc.mdx
@@ -234,7 +234,7 @@ curl -X POST http://localhost:8083/v1alpha/models/yolov4/instances/v1.0-cpu:test
 
 </ CH.Code>
 
-In which `http://localhost:8083` is the default URL of the `model-backend`.
+In which `http://localhost:8083` is the `model-backend` default URL.
 
 ### Find the credentials JSON file
 

--- a/src/pages/docs/import-models/artivc.mdx
+++ b/src/pages/docs/import-models/artivc.mdx
@@ -234,7 +234,7 @@ curl -X POST http://localhost:8083/v1alpha/models/yolov4/instances/v1.0-cpu:test
 
 </ CH.Code>
 
-In which `http://localhost:8083` is the `model-backend` default URL.
+in which `http://localhost:8083` is the `model-backend` default URL.
 
 ### Find the credentials JSON file
 

--- a/src/pages/docs/import-models/github.mdx
+++ b/src/pages/docs/import-models/github.mdx
@@ -391,7 +391,7 @@ curl -X POST http://localhost:8083/v1alpha/models/yolov4/instances/v1.0-cpu:test
 
 </ CH.Code>
 
-In which `http://localhost:8083` is the default URL of the `model-backend`.
+In which `http://localhost:8083` is the `model-backend` default URL.
 
 ## Limitations
 

--- a/src/pages/docs/import-models/github.mdx
+++ b/src/pages/docs/import-models/github.mdx
@@ -391,7 +391,7 @@ curl -X POST http://localhost:8083/v1alpha/models/yolov4/instances/v1.0-cpu:test
 
 </ CH.Code>
 
-In which `http://localhost:8083` is the `model-backend` default URL.
+in which `http://localhost:8083` is the `model-backend` default URL.
 
 ## Limitations
 

--- a/src/pages/docs/import-models/huggingface.mdx
+++ b/src/pages/docs/import-models/huggingface.mdx
@@ -104,4 +104,4 @@ curl -X POST http://localhost:8083/v1alpha/models/vit-base-patch16-224/instances
 
 </ CH.Code>
 
-In which `http://localhost:8083` is the default URL of the `model-backend`.
+In which `http://localhost:8083` is the `model-backend` default URL.

--- a/src/pages/docs/import-models/huggingface.mdx
+++ b/src/pages/docs/import-models/huggingface.mdx
@@ -104,4 +104,4 @@ curl -X POST http://localhost:8083/v1alpha/models/vit-base-patch16-224/instances
 
 </ CH.Code>
 
-In which `http://localhost:8083` is the `model-backend` default URL.
+in which `http://localhost:8083` is the `model-backend` default URL.

--- a/src/pages/docs/import-models/local.mdx
+++ b/src/pages/docs/import-models/local.mdx
@@ -210,4 +210,4 @@ curl -X POST http://localhost:8083/v1alpha/models/yolov4/instances/latest:test-m
 
 </ CH.Code>
 
-In which `http://localhost:8083` is the default URL of the `model-backend`.
+In which `http://localhost:8083` is the `model-backend` default URL.

--- a/src/pages/docs/import-models/local.mdx
+++ b/src/pages/docs/import-models/local.mdx
@@ -210,4 +210,4 @@ curl -X POST http://localhost:8083/v1alpha/models/yolov4/instances/latest:test-m
 
 </ CH.Code>
 
-In which `http://localhost:8083` is the `model-backend` default URL.
+in which `http://localhost:8083` is the `model-backend` default URL.

--- a/src/pages/docs/source-connectors/grpc.mdx
+++ b/src/pages/docs/source-connectors/grpc.mdx
@@ -55,6 +55,6 @@ curl -X POST http://localhost:8082/v1alpha/source-connectors -d '{
 }'
 ```
 
-, where `localhost:8082` is the URL of the `connector-backend`.
+, where `localhost:8082` is the `connector-backend` URL.
 
 For other operations, please refer to the [VDP Protobufs](https://buf.build/instill-ai/protobufs).

--- a/src/pages/docs/source-connectors/grpc.mdx
+++ b/src/pages/docs/source-connectors/grpc.mdx
@@ -55,6 +55,6 @@ curl -X POST http://localhost:8082/v1alpha/source-connectors -d '{
 }'
 ```
 
-, where `localhost:8082` is the `connector-backend` URL.
+where `localhost:8082` is the `connector-backend` default URL.
 
 For other operations, please refer to the [VDP Protobufs](https://buf.build/instill-ai/protobufs).

--- a/src/pages/docs/source-connectors/http.mdx
+++ b/src/pages/docs/source-connectors/http.mdx
@@ -55,6 +55,6 @@ curl -X POST http://localhost:8082/v1alpha/source-connectors -d '{
 }'
 ```
 
-, where `localhost:8082` is the URL of the `connector-backend`.
+, where `localhost:8082` is the `connector-backend` URL.
 
 For other operations, please refer to the [VDP Protobufs](https://buf.build/instill-ai/protobufs).

--- a/src/pages/docs/source-connectors/http.mdx
+++ b/src/pages/docs/source-connectors/http.mdx
@@ -55,6 +55,6 @@ curl -X POST http://localhost:8082/v1alpha/source-connectors -d '{
 }'
 ```
 
-, where `localhost:8082` is the `connector-backend` URL.
+where `localhost:8082` is the `connector-backend` default URL.
 
 For other operations, please refer to the [VDP Protobufs](https://buf.build/instill-ai/protobufs).

--- a/src/pages/docs/start-here/configuration.mdx
+++ b/src/pages/docs/start-here/configuration.mdx
@@ -27,7 +27,7 @@ Read the default configuration files for a full overview of all supported config
 [`model-backend`](https://github.com/instill-ai/model-backend/blob/main/config/config.yaml) and
 [`mgmt-backend`](https://github.com/instill-ai/mgmt-backend/blob/main/config/config.yaml)
 
-**Configuring VDP service version**
+#### Configuring VDP service version
 
 Set the environment variable for a specific service to determine which version to use in VDP.
 
@@ -48,9 +48,9 @@ TEMPORAL_UI_VERSION=<temporal-ui-version>
 ```
 
 The combination of default versions in `.env` file is fully tested for compatibility.
-Unless you are debugging and testing, updating the default versions in `env` file is discouraged.
+Unless you are debugging and testing, updating the default versions in `.env` file is discouraged.
 
-**Configuring VDP domain**
+#### Configuring VDP domain
 
 Set the domain name to access VDP by overriding the environment variable `DOMAIN`:
 

--- a/src/pages/docs/start-here/getting-started.mdx
+++ b/src/pages/docs/start-here/getting-started.mdx
@@ -43,8 +43,7 @@ Make sure you have the prerequisites set up:
 Get started locally by running:
 
 ```shellscript
-git clone https://github.com/instill-ai/vdp.git
-cd vdp
+git clone https://github.com/instill-ai/vdp.git && cd vdp
 make all
 ```
 

--- a/src/pages/docs/tutorials/build-a-sync-cls-pipeline.mdx
+++ b/src/pages/docs/tutorials/build-a-sync-cls-pipeline.mdx
@@ -144,7 +144,7 @@ curl -X POST http://localhost:8081/v1alpha/pipelines -d '{
 
 #### Step 1: Add a HTTP source
 
-`http://localhost:8082` is the default URL of the VDP `connector-backend`.
+`http://localhost:8082` is the `connector-backend` default URL.
 
 ```shellscript focus=1:8
 
@@ -154,7 +154,7 @@ curl -X POST http://localhost:8081/v1alpha/pipelines -d '{
 
 #### Step 2: Import a model from GitHub
 
-`http://localhost:8083` is the default URL of the VDP `model-backend`.
+`http://localhost:8083` is the `model-backend` default URL.
 
 ```shellscript focus=10:16
 
@@ -182,7 +182,7 @@ Choose the model instance `v1.0-cpu` to deploy.
 
 #### Step 5: Create your first pipeline
 
-`http://localhost:8081` is the default URL of the VDP `pipeline-backend`.
+`http://localhost:8081` is the `pipeline-backend` default URL.
 
 ```shellscript focus=27:38
 
@@ -230,7 +230,7 @@ curl -X POST http://localhost:8081/v1alpha/pipelines/classification:trigger-mult
 
 </CH.Code>
 
-in which `http://localhost:8081` is the default URL of the VDP `pipeline-backend`.
+in which `http://localhost:8081` is the `pipeline-backend` default URL.
 
 A HTTP response will return
 

--- a/src/pages/docs/tutorials/build-an-async-det-pipeline.mdx
+++ b/src/pages/docs/tutorials/build-an-async-det-pipeline.mdx
@@ -154,7 +154,7 @@ curl -X POST http://localhost:8081/v1alpha/pipelines -d '{
 
 #### Step 1: Add a HTTP source
 
-`http://localhost:8082` is the default URL of the VDP `connector-backend`.
+`http://localhost:8082` is the `connector-backend` default URL.
 
 ```shellscript focus=1:8
 
@@ -164,7 +164,7 @@ curl -X POST http://localhost:8081/v1alpha/pipelines -d '{
 
 #### Step 2: Import a model from GitHub
 
-`http://localhost:8083` is the default URL of the VDP `model-backend`.
+`http://localhost:8083` is the `model-backend` default URL.
 
 ```shellscript focus=10:16
 
@@ -192,7 +192,7 @@ Choose the model instance `v1.0-cpu` to deploy.
 
 #### Step 5: Create your first pipeline
 
-`http://localhost:8081` is the default URL of the VDP `pipeline-backend`.
+`http://localhost:8081` is the `pipeline-backend` default URL.
 
 ```shellscript focus=36:48
 
@@ -239,7 +239,7 @@ curl -X POST http://localhost:8081/v1alpha/pipelines/detection:trigger-multipart
 
 </CH.Code>
 
-in which `http://localhost:8081` is the default URL of the VDP `pipeline-backend`.
+in which `http://localhost:8081` is the `pipeline-backend` default URL.
 
 A HTTP response will return
 


### PR DESCRIPTION
Because

- we are rapidly iterating the documentation 

This commit

- refine wording 
