### PR TITLE
docs: fix typo

### DIFF
--- a/src/pages/docs/start-here/faq.mdx
+++ b/src/pages/docs/start-here/faq.mdx
@@ -14,7 +14,7 @@ export default ({ children }) => (
 
 This page curates a list of frequently asked questions from our users, friends, candidates, investors, random people, etc.
 
-## Essence
+## Essentials
 
 <details>
 <summary>**Why do you build VDP?**</summary>


### PR DESCRIPTION
Because

- we're iterating the docs

This commit

- fix typos
