### PR TITLE
docs(core-concepts,development,import-models,prepare-models,start-here,tutorials): adopt text block

### DIFF
--- a/src/pages/docs/core-concepts/cv-task.mdx
+++ b/src/pages/docs/core-concepts/cv-task.mdx
@@ -189,7 +189,9 @@ Normally, a keypoint detection task takes an image as the input, and outputs the
 
 ![Keypoint detection task](/docs-assets/core-concepts/cv-task-keypoint.svg)
 
-> Keypoint detection task only allows single image input for now, will allow batch processing soon.
+:::info{type=warning}
+Keypoint detection task only allows single image input for now, will allow batch processing soon.
+:::
 
 <CH.Code>
 ```json current

--- a/src/pages/docs/core-concepts/overview.mdx
+++ b/src/pages/docs/core-concepts/overview.mdx
@@ -54,7 +54,7 @@ VDP implements [Airbyte Protocol](https://docs.airbyte.com/understanding-airbyte
 
 ## Console
 
-**Console** is the _no-code_ VDP platform to manage resources and monitor service metrics. The goal is to provide an unified, clean and intuitive user experience of VDP.
+**Console** is the _no-code_ VDP platform to manage resources and monitor service metrics. The goal is to provide a unified, clean and intuitive user experience of VDP.
 
 **Console** is maintained in [console](https://github.com/instill-ai/console).
 

--- a/src/pages/docs/core-concepts/pipeline.mdx
+++ b/src/pages/docs/core-concepts/pipeline.mdx
@@ -79,7 +79,7 @@ For example, this `recipe` defines an`ASYNC` pipeline to detect images by YOLOv7
 }
 ```
 
-#### `FETCH` mode (coming soon)
+#### `FETCH` mode (coming soon!)
 
 A pipeline in the `FETCH` mode performs scheduled workload to regularly fetch data from the **Source** to send to **Model** for inference and write to destination in the end.
 

--- a/src/pages/docs/development/setup-local-development.mdx
+++ b/src/pages/docs/development/setup-local-development.mdx
@@ -15,8 +15,10 @@ export default ({ children }) => (
 VDP is built with the microservice architecture. To develop each service independently, we assign [profiles](https://docs.docker.com/compose/profiles) to each service in the [`docker-compose-dev.yml`](https://github.com/instill-ai/vdp/blob/main/docker-compose-dev.yml) file in VDP.
 This allows us to selectively enabling services for various usages, e.g., debugging or development.
 
-> Services are associated with profiles through the `profiles` attribute, which takes an array of profile names.
-> A service will be started only if one of its profile names is activated. A service without `profiles` will always be started.
+:::info{type=info}
+Services are associated with profiles through the `profiles` attribute, which takes an array of profile names.
+A service will be started only if one of its profile names is activated. A service without `profiles` will always be started.
+:::
 
 VDP assigns five different profile names:
 

--- a/src/pages/docs/import-models/artivc.mdx
+++ b/src/pages/docs/import-models/artivc.mdx
@@ -156,7 +156,9 @@ If you list the files in the remote storage repository, the file structure will 
 
 🎉 If you've followed the above steps, just run the setup guide below, VDP wll import the model accordingly.
 
-> Use `avc get` to download data. See [here](https://artivc.io/usage/getting-started) for more information.
+:::info{type=tip}
+Use `avc get` to download data. See [here](https://artivc.io/usage/getting-started) for more information.
+:::
 
 ### No-code setup
 

--- a/src/pages/docs/import-models/github.mdx
+++ b/src/pages/docs/import-models/github.mdx
@@ -42,7 +42,9 @@ GitHub limits the size of files ([max 100 MB](https://docs.github.com/en/reposit
 
 Assume Git LFS is [installed](https://git-lfs.github.com/), this guideline publishes model files in a repository on GitHub.
 
-> GitHub has a limit of [2 GB per repository](https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-git-large-file-storage) for using Git LFS.
+:::info{type=info}
+GitHub has a limit of [2 GB per repository](https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-git-large-file-storage) for using Git LFS.
+:::
 
 **Step 1: Create a GitHub repository**
 
@@ -139,7 +141,9 @@ git lfs ls-files
 git push -u origin main
 ```
 
-> As the [official GitHub Docs](https://docs.github.com/en/repositories/working-with-files/managing-large-files/configuring-git-large-file-storage) suggested, please commit the local `.gitattributes` file into your repository.
+:::info{type=info}
+As the [official GitHub Docs](https://docs.github.com/en/repositories/working-with-files/managing-large-files/configuring-git-large-file-storage) suggested, please commit the local `.gitattributes` file into your repository.
+:::
 
 After uploading all files successfully, go to your GitHub repository. You should see all model files are uploaded with the `.onnx` file in Git LFS.
 
@@ -214,6 +218,7 @@ A few [DVC internal directories and files](https://dvc.org/doc/user-guide/projec
 
 ```shellscript
 git status
+
 # Output
 ...
 Changes to be committed:
@@ -233,10 +238,10 @@ Let's use `dvc add` to track the ONNX model file:
 dvc add yolov4-infer/1/model.onnx
 
 # Output
-> To track the changes with git, run:
+To track the changes with git, run:
 
-    git add yolov4-infer/1/model.onnx.dvc yolov4-infer/1/.gitignore
-    ...
+  git add yolov4-infer/1/model.onnx.dvc yolov4-infer/1/.gitignore
+  ...
 ```
 
 DVC stores the model file information in a `.dvc` metadata file and lists it in `.gitignore`. The `.dvc` file is a placeholder for the original large file.
@@ -246,9 +251,9 @@ cat yolov4-infer/1/model.onnx.dvc
 
 # Output
 outs:
-- md5: 2e0eeb4de8da2a0663ae3eb4a0dabbce
-  size: 257470589
-  path: model.onnx
+  - md5: 2e0eeb4de8da2a0663ae3eb4a0dabbce
+    size: 257470589
+    path: model.onnx
 ```
 
 `dvc add` moves the large file into `.dvc/cache`:
@@ -272,10 +277,13 @@ git commit -m "feat: add model file"
 
 Currently, VDP supports fetching models from public Google Cloud Storage (GCS). Let's set up the [remote storage location with a public GCS bucket](https://dvc.org/doc/command-reference/remote/add#google-cloud-storage):
 
-> Preparation
->
-> - [Create a storage bucket](https://cloud.google.com/storage/docs/creating-buckets) before adding DVC remote
-> - Make sure to run `gcloud auth application-default login` or other ways to authenticate and access GCS.
+:::info{type=info}
+
+Prepare the GCS bucket:
+
+- [Create a storage bucket](https://cloud.google.com/storage/docs/creating-buckets) before adding DVC remote
+- Make sure to run `gcloud auth application-default login` or other ways to authenticate and access GCS.
+  :::
 
 ```shellscript
 # Create a new data remote
@@ -321,7 +329,9 @@ Go to your GitHub repository and follow the [GitHub Docs to create a new release
 
 🎉 If you've followed the above steps to store the model in remote storage and version it within a GitHub repository using [DVC](https://dvc.org/doc/user-guide/basic-concepts/dvc-project#dvc-repository), just run the setup guide below, VDP will import the model accordingly.
 
-> Use `dvc pull` to retrieve DVC-tracked files from remote storage. See [here](https://dvc.org/doc/start/data-management?tab=Mac-Linux#retrieving) for more information.
+:::info{type=tip}
+Use `dvc pull` to retrieve DVC-tracked files from remote storage. See [here](https://dvc.org/doc/start/data-management?tab=Mac-Linux#retrieving) for more information.
+:::
 
 ### No-code setup
 

--- a/src/pages/docs/prepare-models/model-card.mdx
+++ b/src/pages/docs/prepare-models/model-card.mdx
@@ -31,7 +31,9 @@ Here shows a model card example of a model imported from a GitHub repository [mo
 
 ![Model card in VDP Console](/docs-assets/prepare-models/console-model-card.png)
 
-> Try our [Import GitHub models](/docs/import-models/github) guideline to import a model from GitHub
+:::info{type=info}
+Try our [Import GitHub models](/docs/import-models/github) guideline to import a model from GitHub
+:::
 
 ## Model card metadata
 
@@ -50,8 +52,10 @@ Tags:
 
 ### Specify a CV Task
 
-> Technically, you can assign different CV Task to model instances of the same model.
-> Howerver, this is strongly discouraged. Model instances of a model should be designed to solve the same CV Task.
+:::info{type=tip}
+Technically, you can assign different CV Task to model instances of the same model.
+Howerver, this is strongly discouraged. Model instances of a model should be designed to solve the same CV Task.
+:::
 
 When importing the model, VDP will detect the `Task` in the model card and verify if output of the model fulfils the CV Task requirements.
 If the model is verified, VDP will automatically convert the model output into format of the corresponding standardised CV Task format whenever using the model.

--- a/src/pages/docs/prepare-models/model-card.mdx
+++ b/src/pages/docs/prepare-models/model-card.mdx
@@ -54,7 +54,7 @@ Tags:
 
 :::info{type=tip}
 Technically, you can assign different CV Task to model instances of the same model.
-Howerver, this is strongly discouraged. Model instances of a model should be designed to solve the same CV Task.
+However, this is strongly discouraged. Model instances of a model should be designed to solve the same CV Task.
 :::
 
 When importing the model, VDP will detect the `Task` in the model card and verify if output of the model fulfils the CV Task requirements.

--- a/src/pages/docs/prepare-models/overview.mdx
+++ b/src/pages/docs/prepare-models/overview.mdx
@@ -50,7 +50,9 @@ The above layout displays a typical VDP model consisting of
 
 You can name `<pre-model>`, `<infer-model>`, `<post-model>` and `<ensemble-model>` folders freely provided that the folder names are clear and semantic. All these models bundle into a deployable model for VDP.
 
-> As long as your model fulfils the required [Triton model repository layout](https://github.com/triton-inference-server/server/blob/main/docs/model_repository.md), it can be safely imported into VDP and deployed online.
+:::info{type=info}
+As long as your model fulfils the required [Triton model repository layout](https://github.com/triton-inference-server/server/blob/main/docs/model_repository.md), it can be safely imported into VDP and deployed online.
+:::
 
 ## Serve models written in Python
 

--- a/src/pages/docs/prepare-models/post-processing.mdx
+++ b/src/pages/docs/prepare-models/post-processing.mdx
@@ -23,7 +23,9 @@ If no task is specified when creating a model, the output will the raw model out
 
 ### Image classification
 
-> Learn more about [Image classification Task](/docs/core-concepts/cv-task#image-classification)
+:::info{type=info}
+Learn more about [Image classification Task](/docs/core-concepts/cv-task#image-classification)
+:::
 
 Assume we have a "cat vs. dog" model to infer whether an image is a cat image or dog image. Create a `labels.txt` file to list all the pre-defined categories, with one category label per line. Add the file to the folder of inference model.
 
@@ -64,7 +66,9 @@ Check the [standarised output for image classification](/docs/core-concepts/cv-t
 
 ### Object detection
 
-> Learn more about [Object detection Task](/docs/core-concepts/cv-task#object-detection)
+:::info{type=info}
+Learn more about [Object detection Task](/docs/core-concepts/cv-task#object-detection)
+:::
 
 Create a Python file with a structure similar to below. The file inherits the `PostDetectionModel` class and implement the `post_process_per_image` abstract method.
 Then, add the file in the post-processing model folder:
@@ -138,7 +142,9 @@ Check the [standardised output for object detection](/docs/core-concepts/cv-task
 
 ### Keypoint detection
 
-> Learn more about [Keypoint detection Task](/docs/core-concepts/cv-task#keypoint-detection)
+:::info{type=info}
+Learn more about [Keypoint detection Task](/docs/core-concepts/cv-task#keypoint-detection)
+:::
 
 Create a Python file with a structure similar to below and add the file in the post-processing model folder:
 
@@ -214,7 +220,9 @@ Check the [standardised output for keypoint detection](/docs/core-concepts/cv-ta
 
 ### Unspecified CV Task
 
-> Learn more about [Unspecified CV Task](/docs/core-concepts/cv-task#what-if-my-task-is-not-standardised-by-by-vdp-yet)
+:::info{type=info}
+Learn more about [Unspecified CV Task](/docs/core-concepts/cv-task#what-if-my-task-is-not-standardised-by-by-vdp-yet)
+:::
 
 If your model is imported without specifying any Task metadata, the model will be recognised to solve an `Unspecified` CV task.
 There is no need to prepare your model outputs to fit any format.

--- a/src/pages/docs/start-here/configuration.mdx
+++ b/src/pages/docs/start-here/configuration.mdx
@@ -66,7 +66,9 @@ To help us better understand how VDP is used and can be improved, VDP collects a
 
 #### What data is collected
 
-> **We value your privacy.** So, we went for the anonymous data and selected a set of details to share from your VDP instance that would give us insights about how to improve VDP without being invasive.
+:::info{type=info}
+We value your privacy. So, we went for the anonymous data and selected a set of details to share from your VDP instance that would give us insights about how to improve VDP without being invasive.
+:::
 
 When a new VDP is running, the usage client in services including `pipeline-backend`, `connector-backend`, `model-backend` and `mgmt-backend` in VDP will ask for a new session, respectively.
 Our usage server returns a token used for future reporting.

--- a/src/pages/docs/start-here/faq.mdx
+++ b/src/pages/docs/start-here/faq.mdx
@@ -72,7 +72,7 @@ If you are interested in the hosting service of VDP, we've started signing up us
 <details>
 <summary>**How do you make money?**</summary>
 
-We offer full management VDP service on Instill Cloud (coming soon!) with Team and Enterprise tiers to organisations that want to get all the power of VDP for their teams, without any hassle.
+We offer fully managed VDP service on Instill Cloud (coming soon!) with Team and Enterprise tiers to organisations that want to get all the power of VDP for their teams, without any hassle.
 
 If you are interested in the hosting service of VDP, we've started signing up users to our private alpha. [Join the waitlist](https://www.instill.tech/get-access/?utm_source=documentation&utm_medium=link) and we'll contact you when we're ready.
 

--- a/src/pages/docs/start-here/instill-cloud.mdx
+++ b/src/pages/docs/start-here/instill-cloud.mdx
@@ -18,7 +18,7 @@ export default ({ children }) => (
 - Start for free, pay as you grow
 
 Access to Instill Cloud is currently by invitation only. If you're interested in the hosting service of VDP,
-[join the waitlist](https://www.instill.tech/get-access/?utm_source=documentation&utm_medium=link) and we'will contact you when we're ready.
+[join the waitlist](https://www.instill.tech/get-access/?utm_source=documentation&utm_medium=link) and we'll contact you when we're ready.
 
 ## We're open to collaboration
 

--- a/src/pages/docs/tutorials/build-a-sync-cls-pipeline.mdx
+++ b/src/pages/docs/tutorials/build-a-sync-cls-pipeline.mdx
@@ -22,7 +22,7 @@ where you can build your first VDP pipeline by clicking **Create your first pipe
 ![Empty pipeline list page of the VDP Console](/docs-assets/tutorials/pipeline-list-empty.png)
 
 :::info{type=tip}
-You can follow the tutorial via the _Pipeline_ page. Or, you can navigate to the _Source_, _Model_ and _Destination_ page to create each component first and use them to configure a pipeline in _Pipeline_ page later.
+You can follow the tutorial via the **Pipeline** page. Or, you can navigate to the **Source**, **Model** and **Destination** page to create each component first and use them to configure a pipeline in **Pipeline** page later.
 :::
 
 #### Add a HTTP source

--- a/src/pages/docs/tutorials/build-a-sync-cls-pipeline.mdx
+++ b/src/pages/docs/tutorials/build-a-sync-cls-pipeline.mdx
@@ -21,7 +21,9 @@ where you can build your first VDP pipeline by clicking **Create your first pipe
 
 ![Empty pipeline list page of the VDP Console](/docs-assets/tutorials/pipeline-list-empty.png)
 
-> You can follow the tutorial via the **Pipeline** page. Or, you can navigate to the **Source**, **Model** and **Destination** page to create each component first and use them to configure a pipeline in **Pipeline** page later.
+:::info{type=tip}
+You can follow the tutorial via the _Pipeline_ page. Or, you can navigate to the _Source_, _Model_ and _Destination_ page to create each component first and use them to configure a pipeline in _Pipeline_ page later.
+:::
 
 #### Add a HTTP source
 
@@ -34,7 +36,9 @@ To set it up,
 
 ![Add a HTTP source to create a SYNC pipeline in the VDP Console](/docs-assets/tutorials/add-a-sync-source-http.png)
 
-> Check our growing list of [Source Connectors](/docs/source-connectors/overview).
+:::info{type=info}
+Check our growing list of [Source Connectors](/docs/source-connectors/overview).
+:::
 
 #### Import a model from GitHub
 
@@ -52,7 +56,9 @@ To set it up,
 
 VDP will fetch all the releases of the GitHub repository. Each release is converted into one model instance, using the release tag as the corresponding model instance ID.
 
-> Check our growing list of [model sources](/docs/import-models/overview) to learn about how to import models from other platforms.
+:::info{type=info}
+Check our growing list of [model sources](/docs/import-models/overview) to learn about how to import models from other platforms.
+:::
 
 #### Deploy a model instance of the imported model
 
@@ -74,10 +80,12 @@ Just
 
 ![Add a HTTP destination to create a SYNC pipeline in the VDP console](/docs-assets/tutorials/add-a-sync-destination-http.png)
 
-> The paired source and destination connectors for pipelines in [`SYNC`](/docs/core-concepts/pipeline#sync-mode) mode:
->
-> - HTTP source → HTTP destination
-> - gRPC source → gRPC destination
+:::info{type=info}
+The paired source and destination connectors for pipelines in [`SYNC`](/docs/core-concepts/pipeline#sync-mode) mode:
+
+- HTTP source → HTTP destination
+- gRPC source → gRPC destination
+  :::
 
 #### Set up the pipeline
 
@@ -192,7 +200,9 @@ Choose the model instance `v1.0-cpu` to deploy.
 
 ## Trigger your pipeline for the first time
 
-> All `SYNC` pipelines are automatically activated.
+:::info{type=info}
+All `SYNC` pipelines are automatically activated.
+:::
 
 Now that the `classification` pipeline is automatically activated, you can make a request to trigger the pipeline to process **multiple** images within a batch via remote image URLs, Base64 or multipart:
 

--- a/src/pages/docs/tutorials/build-an-async-det-pipeline.mdx
+++ b/src/pages/docs/tutorials/build-an-async-det-pipeline.mdx
@@ -21,7 +21,9 @@ where you can build your first VDP pipeline by clicking **Create your first pipe
 
 ![Empty pipeline list page of the VDP Console](/docs-assets/tutorials/pipeline-list-empty.png)
 
-> You can follow the tutorial via the **Pipeline** page. Or, you can navigate to the **Source**, **Model** and **Destination** page to create each component first and use them to configure a pipeline in **Pipeline** page later.
+:::info{type=tip}
+You can follow the tutorial via the _Pipeline_ page. Or, you can navigate to the _Source_, _Model_ and _Destination_ page to create each component first and use them to configure a pipeline in _Pipeline_ page later.
+:::
 
 #### Add a HTTP source
 
@@ -34,7 +36,9 @@ To set it up,
 
 ![Add a HTTP source to create an async pipeline in the VDP Console](/docs-assets/tutorials/add-an-async-source-http.png)
 
-> Check our growing list of [Source Connectors](/docs/source-connectors/overview).
+:::info{type=info}
+Check our growing list of [Source Connectors](/docs/source-connectors/overview).
+:::
 
 #### Import a model from GitHub
 
@@ -52,7 +56,9 @@ To set it up,
 
 VDP will fetch all the releases of the GitHub repository. Each release is converted into one model instance, using the release tag as the corresponding model instance ID.
 
-> Check our growing list of [model sources](/docs/import-models/overview) to learn about how to import models from other platforms.
+:::info{type=info}
+Check our growing list of [model sources](/docs/import-models/overview) to learn about how to import models from other platforms.
+:::
 
 #### Deploy a model instance of the imported model
 
@@ -75,7 +81,9 @@ To set it up,
 
 ![Add a PostgreSQL destination to create a pipeline in the VDP console](/docs-assets/tutorials/add-a-destination-postgres.png)
 
-> Make sure the PostgreSQL is accessible by VDP using the specified `Host` and `Port`, and the `tutorial` database has been created in advance.
+:::info{type=info}
+Make sure the PostgreSQL is accessible by VDP using the specified `Host` and `Port`, and the `tutorial` database has been created in advance.
+:::
 
 #### Set up the pipeline
 


### PR DESCRIPTION
Because

- we're iterating the docs

This commit

- use text blocks
- refactor text block style
  - make block header smaller to 16px 
  - change link text colour to text block colour
  - reduce bottom padding  