### PR TITLE
feat: update selection color at code-block, highlight current hast at toc

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ pnpm run storybook
 
 # About how to contribute to Documentation
 
-## Every document lie under the `/src/pages/docs` folder.
+## Every document lie under the `/docs` folder.
 
-- The routing will match the path, take getting-started page for example, its path is `/src/pages/docs/start-here/getting-started.mdx` the url will be `https://www.instill.tech/docs/start-here/getting-started`
+- The routing will match the path, take getting-started page for example, its path is `/docs/start-here/getting-started.mdx` the url will be `https://www.instill.tech/docs/start-here/getting-started`
 - The file name and the folder name only allow `kebab-case`.
 
 ## Navbar and Sidebar

--- a/src/components/docs/LeftSidebar/LeftSidebar.tsx
+++ b/src/components/docs/LeftSidebar/LeftSidebar.tsx
@@ -5,10 +5,9 @@ import Image from "next/future/image";
 
 export type LeftSidebarProps = {
   leftSidebar: Sidebar["leftSidebar"];
-  currentPagePath: string;
 };
 
-const LeftSidebar = ({ leftSidebar, currentPagePath }: LeftSidebarProps) => {
+const LeftSidebar = ({ leftSidebar }: LeftSidebarProps) => {
   return (
     <>
       <style>
@@ -44,7 +43,6 @@ const LeftSidebar = ({ leftSidebar, currentPagePath }: LeftSidebarProps) => {
               items={section.items}
               text={section.text}
               collapsible={section.collapsible}
-              currentPagePath={currentPagePath}
               link={section.link}
             />
           </div>

--- a/src/components/docs/LeftSidebar/Section.tsx
+++ b/src/components/docs/LeftSidebar/Section.tsx
@@ -9,20 +9,11 @@ export type SectionProps = {
   text: string;
   items: SidebarItem[];
   collapsible?: boolean;
-  currentPagePath: string;
   link?: string;
 };
 
-const Section = ({
-  text,
-  items,
-  collapsible,
-  currentPagePath,
-  link,
-}: SectionProps) => {
+const Section = ({ text, items, collapsible, link }: SectionProps) => {
   const [collapsed, setCollapsed] = useState(false);
-  const baseIconStyle =
-    "absolute w-4 h-4 top-2 bottom-2 right-2 fill-instillGrey500";
 
   const toggle = () => {
     if (collapsible) {
@@ -31,6 +22,8 @@ const Section = ({
   };
 
   const router = useRouter();
+
+  console.log(router);
 
   const toLink = () => {
     if (link) {
@@ -85,7 +78,7 @@ const Section = ({
               key={item.text}
               className={cn(
                 "text-sm hover:text-instillBlue50 font-normal transition ease-in-out duration-300",
-                item.link === currentPagePath
+                item.link === router.asPath.split("#")[0]
                   ? "text-instillBlue50"
                   : "text-instillGrey80"
               )}

--- a/src/components/docs/RightSidebar/TableOfContent.tsx
+++ b/src/components/docs/RightSidebar/TableOfContent.tsx
@@ -1,4 +1,7 @@
-import { MouseEvent, useCallback } from "react";
+import cn from "clsx";
+import { useEffect, useState } from "react";
+import { Nullable } from "@/types/instill";
+import { useRouter } from "next/router";
 
 export type TableOfContentProps = {
   headers: {
@@ -9,15 +12,25 @@ export type TableOfContentProps = {
 };
 
 const TableOfContent = ({ headers }: TableOfContentProps) => {
-  // const handleClick = useCallback(
-  //   (e: MouseEvent<HTMLAnchorElement>, slug: string) => {
-  //     //e.preventDefault();
-  //     document.querySelector(`#${slug}`).scrollIntoView({
-  //       behavior: "smooth",
-  //     });
-  //   },
-  //   []
-  // );
+  const router = useRouter();
+  const [currentHash, setCurrentHash] = useState<Nullable<string>>(null);
+
+  useEffect(() => {
+    const handleHashChange = (event: HashChangeEvent) => {
+      setCurrentHash(event.newURL.split("#")[1]);
+    };
+
+    window.addEventListener("hashchange", handleHashChange);
+    return () => {
+      window.removeEventListener("hashchange", handleHashChange);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!router.isReady) return;
+
+    setCurrentHash(router.asPath.split("#")[1]);
+  }, [router]);
 
   return (
     <div className="flex flex-col mb-10">
@@ -26,12 +39,23 @@ const TableOfContent = ({ headers }: TableOfContentProps) => {
         {headers.map((header) => (
           <li
             key={header.slug}
-            className="group my-2.5 border-l-2 border-slate-300 py-0.5 pl-4 text-sm hover:border-instillBlue50"
+            className={cn(
+              "group border-l-2 my-1.5 py-0.5 pl-[15px] text-sm hover:border-instillBlue50",
+              currentHash === header.slug
+                ? "border-instillBlue50"
+                : "border-instillGrey50"
+            )}
           >
             <a
-              className="block truncate text-instillGrey50 group-hover:text-instillBlue50"
+              className={cn(
+                "block truncate group-hover:text-instillBlue50",
+                currentHash === header.slug
+                  ? "text-instillBlue50"
+                  : "text-instillGrey50"
+              )}
               href={`#${header.slug}`}
-              style={{ paddingLeft: `${(header.depth - 1) * 10}px` }}
+              style={{ paddingLeft: `${(header.depth - 2) * 12}px` }}
+              onClick={() => setCurrentHash(header.slug)}
             >
               {header.text}
             </a>

--- a/src/pages/docs/[...path].tsx
+++ b/src/pages/docs/[...path].tsx
@@ -146,23 +146,23 @@ export const getStaticProps: GetStaticProps<DocsProps> = async ({
 
   // Access GitHub API to retrieve the info of Committer
 
-  // const commits = await getRepoFileCommits(
-  //   "instill-ai",
-  //   "instill.tech",
-  //   "docs/" + relativePath + ".mdx"
-  // );
+  const commits = await getRepoFileCommits(
+    "instill-ai",
+    "instill.tech",
+    "docs/" + relativePath + ".mdx"
+  );
 
   let lastEditedTime: Nullable<string> = null;
   let author: Nullable<string> = null;
   let authorGithubUrl: Nullable<string> = null;
 
-  // if (commits.length > 0) {
-  //   const time = new Date(commits[0].commit.author.date).toLocaleString();
+  if (commits.length > 0) {
+    const time = new Date(commits[0].commit.author.date).toLocaleString();
 
-  //   lastEditedTime = time;
-  //   author = commits[0].commit.author.name;
-  //   authorGithubUrl = commits[0].author.html_url;
-  // }
+    lastEditedTime = time;
+    author = commits[0].commit.author.name;
+    authorGithubUrl = commits[0].author.html_url;
+  }
 
   // We use remark to correctly get the headers
 
@@ -215,11 +215,12 @@ const DocsPage = ({
           }
         `}
       </style>
-      <style global jsx>{`
-        html {
-          scroll-behavior: smooth;
-        }
-      `}
+      <style global jsx>
+        {`
+          html {
+            scroll-behavior: smooth;
+          }
+        `}
       </style>
       <PageHead
         pageTitle={`${mdxSource.frontmatter.title} | Documentation`}

--- a/src/pages/docs/[...path].tsx
+++ b/src/pages/docs/[...path].tsx
@@ -233,10 +233,7 @@ const DocsPage = ({
             leftSidebarIsOpen ? "translate-x-0" : "-translate-x-full"
           )}
         >
-          <LeftSidebar
-            leftSidebar={docsConfig.sidebar.leftSidebar}
-            currentPagePath={router.pathname}
-          />
+          <LeftSidebar leftSidebar={docsConfig.sidebar.leftSidebar} />
         </aside>
 
         {leftSidebarIsOpen ? (

--- a/src/styles/docs.css
+++ b/src/styles/docs.css
@@ -173,3 +173,8 @@ article > h2:hover span.heading-anchor-hash, h3:hover span.heading-anchor-hash, 
   font-size: 16px;
   font-weight: 500;
 }
+
+.ch-codeblock ::selection {
+  background-color: rgba(64, 168, 245, 0.5);
+  opacity: 0.8;
+}


### PR DESCRIPTION
Because

- The selection color at code-block is too light.
- We need to indicate what section the user is currently at.

This commit

- Update selection color at code-block
- Highlight current hast at toc
