### PR TITLE
docs(import-models): unify feature section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,38 @@
-# Contribution
+# instill.tech
+
+This repository maintains the Instill AI product website and VDP documentation.
+
+## Contribution
 1. Clone the github
 2. `pnpm install`
 
-# Build up next app
+## Build up next app
+```
 pnpm run dev
+```
 
-# Build up storybook
+## Build up storybook
+```
 pnpm run storybook
+```
 
+## About how to contribute to Documentation
 
-# About how to contribute to Documentation
-
-## Every document lie under the `/docs` folder.
+### Every document lie under the `/docs` folder.
 
 - The routing will match the path, take getting-started page for example, its path is `/docs/start-here/getting-started.mdx` the url will be `https://www.instill.tech/docs/start-here/getting-started`
 - The file name and the folder name only allow `kebab-case`.
 
-## Navbar and Sidebar
+### Navbar and Sidebar
 
 You could adjust Navbar and Sidebar item in `docs.config.tsx` in the root.
 
 - Please add every page in the sidebar. 
 - Please follow the type instruction.
 
-## About the extended markdown syntax
+### About the extended markdown syntax
 
-### Info-block
+#### Info-block
 
 - We offer four info-block variant: info, warning, danger and tip. No custom variant allowed, if you fill in other variant, the build will failed. 
 - Please do enclose the info-block with proper syntax, every missed ::: will cause some unwanted behavior.(Currently, we don't have way to detect this kind of syntax error)
@@ -55,12 +62,12 @@ This is info block with danger type
 :::
 ```
 
-### Youtube embed
+#### YouTube embed
 
-- We offer youtube embed
-- Currently we don't support customize dimension
+- We offer YouTube embed
+- Currently we don't support custom dimensions
 
-#### Syntax
+##### Syntax
 
 ```md
 ::youtube[title]{#id}
@@ -72,6 +79,6 @@ Example
 ::youtube[This is a cat video]{#2MP5Ov_H4Go}
 ```
 
-#### About how to get the youtube id
+##### How to get the YouTube video id
 
-You could get video id with regular youtube url. For example `https://www.youtube.com/watch?v=2MP5Ov_H4Go&ab_channel=NaturalWorldTriumph`. The youtube id is after `watch?v=` that is `2MP5Ov_H4Go`.
+You can get video id with regular YouTube url. For example `https://www.youtube.com/watch?v=2MP5Ov_H4Go&ab_channel=NaturalWorldTriumph`. The YouTube id is after `watch?v=` that is `2MP5Ov_H4Go`.

--- a/docs/import-models/artivc.mdx
+++ b/docs/import-models/artivc.mdx
@@ -7,14 +7,16 @@ description: "Learn about how to import ArtiVC managed models into the open-sour
 
 The `ArtiVC` model definition allows you to import models versioned by [ArtiVC](https://artivc.io/).
 
-## Supported storage backends
+## Feature
+
+Currently, VDP supports importing models from
 
 - ✅ Google Cloud Storage (GCS)
-- 🚧 Local Filesystem
-- 🚧 Remote Filesystem (SSH)
-- 🚧 AWS S3
-- 🚧 Azure Blob Storage
-- 🚧 Rclone
+- 🚧 Local Filesystem (coming soon!)
+- 🚧 Remote Filesystem (SSH) (coming soon!)
+- 🚧 AWS S3 (coming soon!)
+- 🚧 Azure Blob Storage (coming soon!)
+- 🚧 Rclone (coming soon!)
 
 ## Release stage
 

--- a/docs/import-models/github.mdx
+++ b/docs/import-models/github.mdx
@@ -7,10 +7,11 @@ description: "Learn about how to import models from GitHub into the open-source 
 
 The `GitHub` model definition allows you to import models from a [GitHub](https://github.com/) repository. Your model files can be tracked with [Git LFS](https://git-lfs.github.com/) or [DVC](https://dvc.org/).
 
-## Features
+## Feature
 
+Currently, VDP supports importing models from
 - ✅ Public GitHub repository
-- 🚧 Private GitHub repository
+- 🚧 Private GitHub repository (coming soon!)
 
 ## Release stage
 
@@ -276,7 +277,7 @@ Prepare the GCS bucket:
 
 - [Create a storage bucket](https://cloud.google.com/storage/docs/creating-buckets) before adding DVC remote
 - Make sure to run `gcloud auth application-default login` or other ways to authenticate and access GCS.
-  :::
+:::
 
 ```shellscript
 # Create a new data remote

--- a/docs/import-models/huggingface.mdx
+++ b/docs/import-models/huggingface.mdx
@@ -7,7 +7,7 @@ description: "Learn about how to import models from Hugging Face into the open-s
 
 The `Hugging Face` model definition allows you to import models from a [Hugging Face](https://huggingface.co/models) repository.
 
-## Supported model tasks
+## Feature
 
 Currently, VDP supports importing models tagged with the following tasks
 

--- a/docs/import-models/local.mdx
+++ b/docs/import-models/local.mdx
@@ -7,6 +7,11 @@ description: "Learn about how to import local models into the open-source visual
 
 The `Local` model definition enables you to import a model from your local machine.
 
+## Feature
+
+Currently, VDP supports importing models from
+- ✅ A local `.zip` file 
+
 ## Release stage
 
 `Alpha`

--- a/docs/start-here/getting-started.mdx
+++ b/docs/start-here/getting-started.mdx
@@ -72,7 +72,7 @@ Jump right in
 
 📔 Check out the [FAQ](faq) and [tutorials](http://localhost:3010/docs/tutorials/build-a-sync-cls-pipeline)
 
-📔 Explore the [Sources](/docs/source-connectors/overview) and [Destinations](/docs/destination-connectors/overview) to find the connectors you want
+📔 Explore the [Source Connectors](/docs/source-connectors/overview) and [Destinations Connectors](/docs/destination-connectors/overview) to find the connectors you want
 
 📔 Explore the APIs of [Protobufs](https://buf.build/instill-ai/protobufs) or [OpenAPI](http://localhost:3001) (after `make all` or `make doc`)
 

--- a/docs/tutorials/build-a-sync-cls-pipeline.mdx
+++ b/docs/tutorials/build-a-sync-cls-pipeline.mdx
@@ -78,7 +78,7 @@ The paired source and destination connectors for pipelines in [`SYNC`](/docs/cor
 
 - HTTP source → HTTP destination
 - gRPC source → gRPC destination
-  :::
+:::
 
 #### Set up the pipeline
 


### PR DESCRIPTION
Because

- we would like to have section layout unified under a topic

This commit

- make `import-models` pages have an identical `Feature` header
