### PR TITLE
docs(tutorial): update async trigger response

### DIFF
--- a/docs/tutorials/build-an-async-det-pipeline.mdx
+++ b/docs/tutorials/build-an-async-det-pipeline.mdx
@@ -243,9 +243,7 @@ in which `http://localhost:8081` is the `pipeline-backend` default URL.
 A HTTP response will return
 
 ```json
-{
-  "model_instance_outputs":[]
-}
+{}
 ```
 
 and in the PostgreSQL `tutorial` database, you should see


### PR DESCRIPTION
Because

- triggering an async pipeline should return `200 OK` with an empty body

This commit

- update the async pipeline triggering response
