### PR TITLE
docs: add warning for Git LFS

### DIFF
--- a/docs/import-models/github.mdx
+++ b/docs/import-models/github.mdx
@@ -10,6 +10,7 @@ The `GitHub` model definition allows you to import models from a [GitHub](https:
 ## Feature
 
 Currently, VDP supports importing models from
+
 - ✅ Public GitHub repository
 - 🚧 Private GitHub repository (coming soon!)
 
@@ -36,8 +37,10 @@ GitHub limits the size of files ([max 100 MB](https://docs.github.com/en/reposit
 
 Assume Git LFS is [installed](https://git-lfs.github.com/), this guideline publishes model files in a repository on GitHub.
 
-:::info{type=info}
-GitHub has a limit of [2 GB per repository](https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-git-large-file-storage) for using Git LFS.
+:::info{type=warning}
+Importing models from GitHub using Git LFS is not recommended unless you're with a private GitHub Enterprise account.
+GitHub has a limit of [2 GB per repository](https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-git-large-file-storage) for using Git LFS
+and bandwidth and storage usage will count against the repository owner's quotas.
 :::
 
 **Step 1: Create a GitHub repository**
@@ -277,7 +280,7 @@ Prepare the GCS bucket:
 
 - [Create a storage bucket](https://cloud.google.com/storage/docs/creating-buckets) before adding DVC remote
 - Make sure to run `gcloud auth application-default login` or other ways to authenticate and access GCS.
-:::
+  :::
 
 ```shellscript
 # Create a new data remote

--- a/docs/import-models/github.mdx
+++ b/docs/import-models/github.mdx
@@ -39,7 +39,6 @@ Assume Git LFS is [installed](https://git-lfs.github.com/), this guideline publi
 
 :::info{type=info}
 Importing models from GitHub using Git LFS is not recommended unless you're with a private GitHub Enterprise account.
-GitHub has a limit of [2 GB per repository](https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-git-large-file-storage) for using Git LFS
 :::
 
 **Step 1: Create a GitHub repository**

--- a/docs/import-models/github.mdx
+++ b/docs/import-models/github.mdx
@@ -40,7 +40,6 @@ Assume Git LFS is [installed](https://git-lfs.github.com/), this guideline publi
 :::info{type=info}
 Importing models from GitHub using Git LFS is not recommended unless you're with a private GitHub Enterprise account.
 GitHub has a limit of [2 GB per repository](https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-git-large-file-storage) for using Git LFS
-and bandwidth and storage usage will count against the repository owner's quotas.
 :::
 
 **Step 1: Create a GitHub repository**

--- a/docs/import-models/github.mdx
+++ b/docs/import-models/github.mdx
@@ -280,7 +280,7 @@ Prepare the GCS bucket:
 
 - [Create a storage bucket](https://cloud.google.com/storage/docs/creating-buckets) before adding DVC remote
 - Make sure to run `gcloud auth application-default login` or other ways to authenticate and access GCS.
-  :::
+:::
 
 ```shellscript
 # Create a new data remote

--- a/docs/import-models/github.mdx
+++ b/docs/import-models/github.mdx
@@ -37,7 +37,7 @@ GitHub limits the size of files ([max 100 MB](https://docs.github.com/en/reposit
 
 Assume Git LFS is [installed](https://git-lfs.github.com/), this guideline publishes model files in a repository on GitHub.
 
-:::info{type=warning}
+:::info{type=info}
 Importing models from GitHub using Git LFS is not recommended unless you're with a private GitHub Enterprise account.
 GitHub has a limit of [2 GB per repository](https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-git-large-file-storage) for using Git LFS
 and bandwidth and storage usage will count against the repository owner's quotas.

--- a/docs/import-models/github.mdx
+++ b/docs/import-models/github.mdx
@@ -38,7 +38,9 @@ GitHub limits the size of files ([max 100 MB](https://docs.github.com/en/reposit
 Assume Git LFS is [installed](https://git-lfs.github.com/), this guideline publishes model files in a repository on GitHub.
 
 :::info{type=info}
-Importing models from GitHub using Git LFS is not recommended unless you're with a private GitHub Enterprise account.
+In general, importing models via this approach is not recommended. GitHub has limited quotas of storage and bandwidth for Git LFS files, and the usage will count against the repository owner's quotas leading you to purchase more when reaching the cap.
+
+Instead, consider using GitHub DVC or ArtiVC approaches.
 :::
 
 **Step 1: Create a GitHub repository**

--- a/docs/start-here/configuration.mdx
+++ b/docs/start-here/configuration.mdx
@@ -75,7 +75,7 @@ For each session, we collect [`Session`](https://github.com/instill-ai/protobufs
 - uptime in seconds to identify the rough life span of the service
 
 Each session is assigned with a random UUID for tracking and identification.
-Then, each session will collect and send its own [`SessionReport`](https://github.com/instill-ai/protobufs/blob/main/vdp/usage/v1alpha/usage.proto#L153-L175) data every one hour:
+Then, each session will collect and send its own [`SessionReport`](https://github.com/instill-ai/protobufs/blob/main/vdp/usage/v1alpha/usage.proto#L153-L175) data every 10 minutes:
 
 - [`MgmtUsageData`](https://github.com/instill-ai/protobufs/blob/main/vdp/usage/v1alpha/usage.proto#L68-L72) reports data for `mgmt-backend` session
   - information of the [onboarded User](/docs/start-here/getting-started#start-building-with-vdp)


### PR DESCRIPTION
Because

- update the documentation

This commit

- add warning for importing model from GitHub using Git LFS
- update usage collection reporting frequency
