### PR TITLE
fix: rename deploy to staging action

### DIFF
--- a/.github/workflows/test-and-deploy-staging.yml
+++ b/.github/workflows/test-and-deploy-staging.yml
@@ -1,4 +1,4 @@
-name: cd-build-test-staging
+name: cd-test-and-deploy-staging
 
 on:
   pull_request:


### PR DESCRIPTION
Because

- rename action to better suit it behavior

This commit

-  rename deploy to staging action
