### PR TITLE
chore: remove non necessary commit and rollback release version to 1.15.0

### DIFF
--- a/.github/workflows/test-and-deploy-staging.yml
+++ b/.github/workflows/test-and-deploy-staging.yml
@@ -1,4 +1,4 @@
-name: cd-build-test-staging
+name: cd-test-and-deploy-staging
 
 on:
   pull_request:


### PR DESCRIPTION
Because

- Yesterday we merge an empty commit to trigger build and deploy to production's action. We need to clean it up.

This commit

- remove non necessary commit and rollback release version to 1.15.0
