### PR TITLE
chore: extend release-action to include docs prefix

### DIFF
--- a/release-please/config.json
+++ b/release-please/config.json
@@ -6,7 +6,8 @@
       "draft": false,
       "prerelease": true,
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": false
+      "bump-patch-for-minor-pre-major": false,
+      "changelog-sections": [{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Miscellaneous","hidden":false}, {"type":"docs","section":"Documentation","hidden":false}]
     }
   }
 }


### PR DESCRIPTION
Because

- We need to make release-bot recognize the docs prefix in the commit

This commit

-  extend release-action to include docs prefix
