### PR TITLE
feat: deprecate default export

### DIFF
--- a/docs.config.tsx
+++ b/docs.config.tsx
@@ -189,10 +189,8 @@ const NAV: NavConfig = {
   ],
 };
 
-const docsConfig = {
+export const docsConfig = {
   site: SITE,
   nav: NAV,
   sidebar: SIDEBAR,
 };
-
-export default docsConfig;

--- a/src/components/docs/DocsLayout.tsx
+++ b/src/components/docs/DocsLayout.tsx
@@ -2,7 +2,7 @@ import { ReactNode, useState } from "react";
 import cn from "clsx";
 
 import { LeftSidebar } from "./LeftSidebar";
-import docsConfig from "../../../docs.config";
+import { docsConfig } from "../../../docs.config";
 import { Nav } from "./Nav";
 
 export type DocsLayoutProps = {

--- a/src/lib/utils/debounce.ts
+++ b/src/lib/utils/debounce.ts
@@ -1,7 +1,7 @@
 // Debounce function
 // ref: https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore#_debounce
 
-const debounce = (func: any, wait: number, immediate?: boolean) => {
+export const debounce = (func: any, wait: number, immediate?: boolean) => {
   let timeout: NodeJS.Timeout;
 
   return function () {
@@ -18,5 +18,3 @@ const debounce = (func: any, wait: number, immediate?: boolean) => {
     if (immediate && !timeout) func.apply(context, args);
   };
 };
-
-export default debounce;

--- a/src/lib/utils/handle.ts
+++ b/src/lib/utils/handle.ts
@@ -1,4 +1,4 @@
-const handle = async <T>(
+export const handle = async <T>(
   promise: Promise<T>,
   defaultError: any = "rejected"
 ): Promise<T[] | [any, T]> => {
@@ -6,5 +6,3 @@ const handle = async <T>(
     .then((data) => [undefined, data])
     .catch((error) => Promise.resolve([error || defaultError, undefined]));
 };
-
-export default handle;

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1,4 +1,2 @@
-import handle from "./handle";
-import debounce from "./debounce";
-
-export { handle, debounce };
+export { handle } from "./handle";
+export { debounce } from "./debounce";

--- a/src/pages/docs/[...path].tsx
+++ b/src/pages/docs/[...path].tsx
@@ -20,7 +20,7 @@ import { remark } from "remark";
 
 import { PageHead } from "@/components/ui";
 import { DocsLayout, RightSidebar, RightSidebarProps } from "@/components/docs";
-import docsConfig from "../../../docs.config";
+import { docsConfig } from "../../../docs.config";
 import { remarkInfoBlock } from "@/lib/markdown/remark-info-block.mjs";
 import { remarkYoutube } from "@/lib/markdown/remark-youtube.mjs";
 import {
@@ -205,14 +205,14 @@ const DocsPage: FC<DocsPageProps> & {
         pageType="docs"
       />
       <div className="grid grid-cols-8">
-        <div className="col-span-8 xl:col-span-6 px-6 md:px-8 max:px-16">
-          <h1 className="font-sans font-semibold text-3xl mb-10">
+        <div className="col-span-8 px-6 md:px-8 xl:col-span-6 max:px-16">
+          <h1 className="mb-10 font-sans text-3xl font-semibold">
             {mdxSource.frontmatter.title}
           </h1>
-          <article id="content" className="prose prose-black max-w-none mb-20">
+          <article id="content" className="prose prose-black mb-20 max-w-none">
             <MDXRemote {...mdxSource} components={{ CH }} />
           </article>
-          <div className="flex flex-row gap-x-2 w-full pb-6 mb-8 border-b">
+          <div className="mb-8 flex w-full flex-row gap-x-2 border-b pb-6">
             {lastEditedTime && author ? (
               <>
                 <p className="ml-auto text-sm text-instillGrey70">
@@ -254,7 +254,7 @@ const DocsPage: FC<DocsPageProps> & {
           </div>
         </div>
 
-        <aside className="hidden xl:block xl:col-span-2">
+        <aside className="hidden xl:col-span-2 xl:block">
           <RightSidebar
             githubEditUrl={
               "https://github.com/instill-ai/instill.tech/edit/main/src/pages" +


### PR DESCRIPTION
This commit clean up all the default export except some config file and the nextjs page component. (#314)
