### PR TITLE
docs(start-here): fix typos

### DIFF
--- a/docs/start-here/faq.mdx
+++ b/docs/start-here/faq.mdx
@@ -184,8 +184,8 @@ Last but not least, we love open source.
 <summary>**Why is the company named Instill AI?**</summary>
 
 We have been attempting to land Vision AI products ever since the surge of deep learning in 2014.
-On the way, we have learned how challenging this can be. To build effective AI products, educate the market about the AI, and eventually see the AI products helping people in real life,
-it is fair to say that we, the whole industry, still have a long way to go.
+On the way, we have learned how challenging this can be. To build effective AI products, educate the market about the AI, and eventually see the AI products helping people in real life.
+It is fair to say that we, the whole industry, still have a long way to go.
 
 We are enthusiastic about being on the journey, to instill the Vision AI gradually to the industry.
 

--- a/docs/start-here/roadmap.mdx
+++ b/docs/start-here/roadmap.mdx
@@ -5,7 +5,7 @@ draft: false
 description: "Public roadmap for the open-source visual data ETL tool VDP https://github.com/instill-ai/vdp"
 ---
 
-VDP is under rapid development. Our team is pushing new features every day to meet the needs of our users. Here is our public high-level roadmap for 2022. If you are interested in what's being worked on right now and what will be explored in the future for the VDP project, please check our [VDP project roadmap](https://github.com/orgs/instill-ai/projects/5/views/4).
+VDP is under rapid development. Our team is pushing new features every day to meet the needs of our users. Here is our public high-level roadmap til the end of 2023. If you are interested in what's being worked on right now and what will be explored in the future for the VDP project, please check our [VDP project roadmap](https://github.com/orgs/instill-ai/projects/5/views/4).
 
 ## 2022 Q4
 


### PR DESCRIPTION
Because

- we need to keep our docs up-to-date

This commit

- fix typos
