### PR TITLE
feat: remove status field and utilize clickup inherit statues

### DIFF
--- a/src/components/career/PositionList/PositionList.tsx
+++ b/src/components/career/PositionList/PositionList.tsx
@@ -36,7 +36,6 @@ export const PositionList = forwardRef<HTMLDivElement, PositionListProps>(
         </p>
         <div className="flex flex-col gap-y-5">
           {positions.map((position) => {
-            if (position.status === "close") return null;
             return (
               <CareerPositionListItem
                 link={`/career/${position.id}-${position.slug}`}

--- a/src/lib/click-up/careerTransformer.spec.ts
+++ b/src/lib/click-up/careerTransformer.spec.ts
@@ -147,34 +147,6 @@ const mockClickUpTask: ClickUpTask = {
       value: 0,
       required: false,
     },
-    {
-      id: "a335016b-6bef-4f7c-9e3e-bd943424324b5",
-      name: "status",
-      type: "drop_down",
-      type_config: {
-        default: 0,
-        placeholder: null,
-        new_drop_down: true,
-        options: [
-          {
-            id: "08a31a6b-2c7a-4509-8bd6-eae83459209d",
-            name: "open",
-            color: null,
-            orderindex: 0,
-          },
-          {
-            id: "f4a886ed-da50-4806-91e9-9eb123545d4e",
-            name: "close",
-            color: null,
-            orderindex: 1,
-          },
-        ],
-      },
-      date_created: "1646376566325",
-      hide_from_guests: false,
-      value: 0,
-      required: false,
-    },
   ],
   dependencies: [],
   linked_tasks: [],
@@ -217,5 +189,4 @@ test("This should transform clickUp task into position details", () => {
   expect(positionDetails.stockOptions).toBe("0.1% - 0.3%");
   expect(positionDetails.workType).toBe("Full time");
   expect(positionDetails.slug).toBe("full-stack-ai-engineer");
-  expect(positionDetails.status).toBe("open");
 });

--- a/src/lib/click-up/clickUp.ts
+++ b/src/lib/click-up/clickUp.ts
@@ -69,7 +69,6 @@ export const transformClickUpTaskToPositionDetails = (
     packageUK: getCustomTextFieldValue("package_uk", task),
     packageTW: getCustomTextFieldValue("package_tw", task),
     postDate: getCustomTextFieldValue("post_date", task),
-    status: getCustomSingleSelectFieldValue("status", task) as "close" | "open",
   };
 };
 

--- a/src/pages/career/[slug].tsx
+++ b/src/pages/career/[slug].tsx
@@ -45,9 +45,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     };
   }
 
-  const positionDetails = transformClickUpTaskToPositionDetails(task);
-
-  if (positionDetails.status === "close") {
+  if (task.status.status !== "Open") {
     return {
       redirect: {
         destination: "/404",
@@ -56,6 +54,8 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
       revalidate: 10,
     };
   }
+
+  const positionDetails = transformClickUpTaskToPositionDetails(task);
 
   return {
     props: {
@@ -76,8 +76,8 @@ export const getStaticPaths: GetStaticPaths = async () => {
     tasks = await listClickUpTasksInListQuery("175663624");
 
     for (const task of tasks) {
-      const position = transformClickUpTaskToPositionDetails(task);
-      if (position.status === "open") {
+      if (task.status.status === "Open") {
+        const position = transformClickUpTaskToPositionDetails(task);
         paths.push({
           params: {
             slug: `${position.id}-${position.slug}`,

--- a/src/pages/career/index.tsx
+++ b/src/pages/career/index.tsx
@@ -45,10 +45,11 @@ export const getStaticProps: GetStaticProps<CareerPageProps> = async () => {
 
   try {
     tasks = await listClickUpTasksInListQuery("175663624");
-
     for (const task of tasks) {
-      const position = transformClickUpTaskToPositionDetails(task);
-      if (position.status === "open") positions.push(position);
+      if (task.status.status === "Open") {
+        const position = transformClickUpTaskToPositionDetails(task);
+        positions.push(position);
+      }
     }
   } catch (err) {
     console.error(

--- a/src/types/instill.ts
+++ b/src/types/instill.ts
@@ -9,7 +9,6 @@ export type PositionInfo = {
   packageUK: string;
   packageTW: string;
   postDate: string;
-  status: "open" | "close";
 };
 
 export type MemberDetails = {


### PR DESCRIPTION
This commit utilize the nature of ClickUp list task api that it will not return closed task in the list to implement the Career page list.