### PR TITLE
fix: remove trailing slash in canonical link

### DIFF
--- a/src/components/ui/PageHead.tsx
+++ b/src/components/ui/PageHead.tsx
@@ -24,7 +24,7 @@ export const PageHead = ({
   let canonicalURL =
     router.asPath === "/"
       ? `${process.env.NEXT_PUBLIC_BASE_URL}${router.asPath}`
-      : `${process.env.NEXT_PUBLIC_BASE_URL}${router.asPath}` + "/";
+      : `${process.env.NEXT_PUBLIC_BASE_URL}${router.asPath}`;
 
   return (
     <>


### PR DESCRIPTION
This commit removes trailing slash in canonical link to be consistent across sitemap, url and internal link (close #367)
