### PR TITLE
fix: fix landing page canonical link

### DIFF
--- a/src/components/ui/PageHead.tsx
+++ b/src/components/ui/PageHead.tsx
@@ -23,7 +23,7 @@ export const PageHead = ({
 
   let canonicalURL =
     router.asPath === "/"
-      ? `${process.env.NEXT_PUBLIC_BASE_URL}${router.asPath}`
+      ? `${process.env.NEXT_PUBLIC_BASE_URL}`
       : `${process.env.NEXT_PUBLIC_BASE_URL}${router.asPath}`;
 
   return (


### PR DESCRIPTION
The landing page canonical link is not correct after #368, this pr fixes this issue.
