### PR TITLE
fix: fix timestamp typo

### DIFF
--- a/tutorials/vdp-cow-counter.mdx
+++ b/tutorials/vdp-cow-counter.mdx
@@ -6,7 +6,7 @@ description: "In this tutorial, we showcase how to build an object detection ETL
 cvTask: "objectDetection"
 sourceConnector: "HTTP"
 destinationConnector: "PostgreSQL"
-publishedOn: "2022-09-22T014:26:00"
+publishedOn: "2022-09-22T14:26:00"
 placeholderColor: "bg-instillYellow50"
 themeImgSrc: "/tutorial-assets/vdp-cow-counter/cover-animation.gif"
 themeImgThumbnailSrc: "/tutorial-assets/vdp-cow-counter/cover-static.png"


### PR DESCRIPTION
This PR fixes timestamp typo on vdp-cow-counter tutorial.
