### PR TITLE
fix: fix DocsLayout max breakpoint issue

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -87,7 +87,7 @@ module.exports = {
       screens: {
         xx: "320px",
         xs: "480px",
-        max: "1600px",
+        max: "1440px",
         xl: "1127px",
         tall: { raw: "(min-height: 800px)" },
         short: { raw: "(min-height: 600px and max-height: 800px)" },


### PR DESCRIPTION
This PR fix DocsLayout breakpoint issue that make the content container had wider width.