### PR TITLE
feat: add additional open graph tag

### DIFF
--- a/src/components/policy/PolicyPageLayout.tsx
+++ b/src/components/policy/PolicyPageLayout.tsx
@@ -13,9 +13,12 @@ export const PolicyPageLayout = ({ meta, children }: PolicyPageLayoutProps) => {
   return (
     <PageBase>
       <PageHead
+        pageType="main"
         pageTitle={meta.title}
         pageDescription={meta.description}
-        pageType="main"
+        additionMeta={null}
+        commitMeta={null}
+        currentArticleMeta={null}
       />
       <ContentContainer
         margin="my-[120px] xl:my-40"

--- a/src/components/ui/PageHead.tsx
+++ b/src/components/ui/PageHead.tsx
@@ -101,11 +101,11 @@ export const PageHead = ({
           <meta property="og:type" content="article" />
           <meta
             property="og:image"
-            content={`${process.env.NEXT_PUBLIC_BASE_URL}/${meta.themeImgThumbnailSrc}`}
+            content={`${process.env.NEXT_PUBLIC_BASE_URL}${meta.themeImgThumbnailSrc}`}
           />
           <meta
             property="twitter:image"
-            content={`${process.env.NEXT_PUBLIC_BASE_URL}/${meta.themeImgThumbnailSrc}`}
+            content={`${process.env.NEXT_PUBLIC_BASE_URL}${meta.themeImgThumbnailSrc}`}
           />
           <meta name="twitter:label1" content="Written by" />
           <meta name="twitter:data1" content={meta.author} />
@@ -135,11 +135,11 @@ export const PageHead = ({
           <meta property="og:type" content="article" />
           <meta
             property="og:image"
-            content={`${process.env.NEXT_PUBLIC_BASE_URL}/${meta.themeImgThumbnailSrc}`}
+            content={`${process.env.NEXT_PUBLIC_BASE_URL}${meta.themeImgThumbnailSrc}`}
           />
           <meta
             property="twitter:image"
-            content={`${process.env.NEXT_PUBLIC_BASE_URL}/${meta.themeImgThumbnailSrc}`}
+            content={`${process.env.NEXT_PUBLIC_BASE_URL}${meta.themeImgThumbnailSrc}`}
           />
           <meta
             property="article:publisher"

--- a/src/components/ui/PageHead.tsx
+++ b/src/components/ui/PageHead.tsx
@@ -1,13 +1,16 @@
 import { useRouter } from "next/router";
 import Head from "next/head";
 import { ReactElement } from "react";
+import { BlogArticleMeta, Nullable, TutorialMeta } from "@/types/instill";
+import { CommitMeta } from "@/lib/github/type";
 
 export type PageHeadProps = {
   pageTitle: string;
-  pageDescription?: string;
-  pageType: "main" | "docs";
-  additionMeta?: ReactElement;
-  ogImage?: string;
+  pageDescription: Nullable<string>;
+  pageType: "main" | "docs" | "tutorial" | "blog";
+  additionMeta: Nullable<ReactElement>;
+  currentArticleMeta: Nullable<TutorialMeta | BlogArticleMeta>;
+  commitMeta: Nullable<CommitMeta>;
 };
 
 export const PageHead = ({
@@ -15,39 +18,164 @@ export const PageHead = ({
   pageDescription,
   pageType,
   additionMeta,
-  ogImage,
+  currentArticleMeta,
+  commitMeta,
 }: PageHeadProps) => {
   const router = useRouter();
-
-  const meta = {
-    type: "website",
-    siteName: "Instill AI",
-    pageTitle,
-    pageDescription,
-  };
 
   const canonicalURL =
     router.asPath === "/"
       ? `${process.env.NEXT_PUBLIC_BASE_URL}`
       : `${process.env.NEXT_PUBLIC_BASE_URL}${router.asPath}`;
 
+  // title, meta or any other elements (e.g. script) need to be contained
+  // as direct children of the Head element, or wrapped into maximum one
+  // level of <React.Fragment> or arrays—otherwise the tags won't be correctly
+  // picked up on client-side navigations.
+
+  // So we can't store openGraph in another OpenGraph component
+
+  const pageMeta = {
+    siteName: "Instill AI",
+    defaultDescription:
+      "Empower modern data stack, tapping the value of unstructured data with our open source community.",
+  };
+
+  const baseOpenGraph = (
+    <>
+      <meta property="og:site_name" content={pageMeta.siteName} />
+      <meta
+        property="og:description"
+        content={pageDescription || pageMeta.defaultDescription}
+      />
+      <meta property="og:title" content={pageTitle} />
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:site" content={pageMeta.siteName} />
+      <meta name="twitter:title" content={pageTitle} />
+      <meta
+        name="twitter:description"
+        content={pageDescription || pageMeta.defaultDescription}
+      />
+    </>
+  );
+
+  let openGraph: Nullable<ReactElement> = null;
+
+  switch (pageType) {
+    case "main": {
+      openGraph = (
+        <>
+          <meta property="og:type" content="website" />
+          <meta
+            property="og:image"
+            content={`${process.env.NEXT_PUBLIC_BASE_URL}/instill-ai-open-graph.png`}
+          />
+          <meta
+            property="twitter:image"
+            content={`${process.env.NEXT_PUBLIC_BASE_URL}/instill-ai-open-graph.png`}
+          />
+        </>
+      );
+      break;
+    }
+    case "docs": {
+      openGraph = (
+        <>
+          <meta property="og:type" content="website" />
+          <meta
+            property="og:image"
+            content={`${process.env.NEXT_PUBLIC_BASE_URL}/instill-ai-open-graph.png`}
+          />
+          <meta
+            property="twitter:image"
+            content={`${process.env.NEXT_PUBLIC_BASE_URL}/instill-ai-open-graph.png`}
+          />
+        </>
+      );
+      break;
+    }
+    case "tutorial": {
+      const meta = currentArticleMeta as TutorialMeta;
+      openGraph = (
+        <>
+          <meta property="og:type" content="article" />
+          <meta
+            property="og:image"
+            content={`${process.env.NEXT_PUBLIC_BASE_URL}/${meta.themeImgThumbnailSrc}`}
+          />
+          <meta
+            property="twitter:image"
+            content={`${process.env.NEXT_PUBLIC_BASE_URL}/${meta.themeImgThumbnailSrc}`}
+          />
+          <meta name="twitter:label1" content="Written by" />
+          <meta name="twitter:data1" content={meta.author} />
+          <meta name="twitter:label2" content="Category" />
+          <meta name="twitter:data2" content={meta.useCase} />
+          <meta
+            property="article:publisher"
+            content="https://www.facebook.com/instilltech"
+          />
+          <meta property="article:published_time" content={meta.publishedOn} />
+          <meta property="article:tag" content={meta.useCase} />
+          {commitMeta && commitMeta.lastEditedTime ? (
+            <meta
+              property="article:modified_time"
+              content={commitMeta.lastEditedTime}
+            />
+          ) : null}
+        </>
+      );
+      break;
+    }
+    case "blog": {
+      const meta = currentArticleMeta as BlogArticleMeta;
+      openGraph = (
+        <>
+          {baseOpenGraph}
+          <meta property="og:type" content="article" />
+          <meta
+            property="og:image"
+            content={`${process.env.NEXT_PUBLIC_BASE_URL}/${meta.themeImgThumbnailSrc}`}
+          />
+          <meta
+            property="twitter:image"
+            content={`${process.env.NEXT_PUBLIC_BASE_URL}/${meta.themeImgThumbnailSrc}`}
+          />
+          <meta
+            property="article:publisher"
+            content="https://www.facebook.com/instilltech"
+          />
+          <meta name="twitter:label1" content="Written by" />
+          <meta name="twitter:data1" content={meta.author} />
+          <meta name="twitter:label2" content="Category" />
+          <meta name="twitter:data2" content={meta.category} />
+          <meta property="article:published_time" content={meta.publishedOn} />
+          <meta property="article:tag" content={meta.category} />
+          {commitMeta && commitMeta.lastEditedTime ? (
+            <meta
+              property="article:modified_time"
+              content={commitMeta.lastEditedTime}
+            />
+          ) : null}
+        </>
+      );
+      break;
+    }
+    default:
+      throw new Error(`Page type not exist: ${pageType}`);
+  }
+
   return (
     <>
       <Head>
-        <title>{meta.pageTitle}</title>
-        {meta.pageDescription && (
-          <meta content={meta.pageDescription} name="description" />
+        <title>{pageTitle}</title>
+        {pageDescription && (
+          <meta content={pageDescription} name="description" />
         )}
         <meta property="og:url" content={canonicalURL} />
         <link rel="canonical" href={canonicalURL} />
-        <meta property="og:type" content={meta.type} />
-        <meta property="og:site_name" content={meta.siteName} />
-        <meta property="og:description" content={meta.pageDescription} />
-        <meta property="og:title" content={meta.pageTitle} />
-        <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:site" content={meta.siteName} />
-        <meta name="twitter:title" content={meta.pageTitle} />
-        <meta name="twitter:description" content={meta.pageDescription} />
+        {baseOpenGraph}
+        {openGraph}
         {additionMeta}
         {pageType === "main" ? (
           <>
@@ -64,22 +192,6 @@ export const PageHead = ({
               href="/instill-ai-favicon-16x16.png"
             />
             <link rel="shortcut icon" href="/instill-ai-favicon.ico" />
-            <meta
-              property="og:image"
-              content={
-                ogImage
-                  ? ogImage
-                  : `${process.env.NEXT_PUBLIC_BASE_URL}/instill-ai-open-graph.png`
-              }
-            />
-            <meta
-              property="twitter:image"
-              content={
-                ogImage
-                  ? ogImage
-                  : `${process.env.NEXT_PUBLIC_BASE_URL}/instill-ai-open-graph.png`
-              }
-            />
           </>
         ) : (
           <>
@@ -96,22 +208,6 @@ export const PageHead = ({
               href="/vdp-favicon-16x16.png"
             />
             <link rel="shortcut icon" href="/vdp-favicon.ico" />
-            <meta
-              property="og:image"
-              content={
-                ogImage
-                  ? ogImage
-                  : `${process.env.NEXT_PUBLIC_BASE_URL}/instill-ai-open-graph.png`
-              }
-            />
-            <meta
-              property="twitter:image"
-              content={
-                ogImage
-                  ? ogImage
-                  : `${process.env.NEXT_PUBLIC_BASE_URL}/instill-ai-open-graph.png`
-              }
-            />
           </>
         )}
       </Head>

--- a/src/components/ui/PageHead.tsx
+++ b/src/components/ui/PageHead.tsx
@@ -109,7 +109,7 @@ export const PageHead = ({
           />
           <meta name="twitter:label1" content="Written by" />
           <meta name="twitter:data1" content={meta.author} />
-          <meta name="twitter:label2" content="Category" />
+          <meta name="twitter:label2" content="Use Case" />
           <meta name="twitter:data2" content={meta.useCase} />
           <meta
             property="article:publisher"

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -85,9 +85,12 @@ const AboutPage: FC<AboutPageProps> & {
   return (
     <>
       <PageHead
+        pageType="main"
         pageTitle="About us | Instill AI"
         pageDescription="Instill AI, founded in 2020 (June 11th 2020, to be more specific), provides no-/low-code tools to convert unstructured data to meaningful data representations."
-        pageType="main"
+        additionMeta={null}
+        commitMeta={null}
+        currentArticleMeta={null}
       />
       <ContentContainer
         margin="my-[120px] xl:my-40"

--- a/src/pages/blog/[...path].tsx
+++ b/src/pages/blog/[...path].tsx
@@ -37,7 +37,7 @@ type BlogPageProps = {
   headers: RightSidebarProps["headers"];
   articles: BlogArticleMeta[];
   commitMeta: Nullable<CommitMeta>;
-  currentArticleMeta: Nullable<BlogArticleMeta>;
+  blogMeta: Nullable<BlogArticleMeta>;
 };
 
 export const getStaticPaths: GetStaticPaths = async () => {
@@ -120,7 +120,7 @@ export const getStaticProps: GetStaticProps<BlogPageProps> = async ({
       headers,
       articles,
       commitMeta,
-      currentArticleMeta: articles.find((e) => e.slug === relativePath) || null,
+      blogMeta: articles.find((e) => e.slug === relativePath) || null,
     },
   };
 };
@@ -131,23 +131,22 @@ type GetLayOutProps = {
 
 const BlogPage: FC<BlogPageProps> & {
   getLayout?: FC<GetLayOutProps>;
-} = ({ mdxSource, commitMeta, headers, articles, currentArticleMeta }) => {
+} = ({ mdxSource, commitMeta, headers, articles, blogMeta }) => {
   const [articleContainerRef, articleContainerDimension] =
     useElementDimension();
 
   const similarArticles = useMemo(() => {
-    if (!currentArticleMeta) return [];
+    if (!blogMeta) return [];
 
     return articles.filter(
-      (e) =>
-        e.category === currentArticleMeta.category &&
-        e.title !== currentArticleMeta.title
+      (e) => e.category === blogMeta.category && e.title !== blogMeta.title
     );
-  }, [articles, currentArticleMeta]);
+  }, [articles, blogMeta]);
 
   return (
     <>
       <PageHead
+        pageType="blog"
         pageTitle={
           mdxSource.frontmatter
             ? `${mdxSource.frontmatter.title} | Blog`
@@ -156,8 +155,9 @@ const BlogPage: FC<BlogPageProps> & {
         pageDescription={
           mdxSource.frontmatter ? mdxSource.frontmatter.description : ""
         }
-        pageType="main"
-        ogImage={`${process.env.NEXT_PUBLIC_BASE_URL}${mdxSource.frontmatter?.themeImgThumbnailSrc}`}
+        commitMeta={commitMeta}
+        currentArticleMeta={blogMeta}
+        additionMeta={null}
       />
       <ContentContainer
         margin="mt-[60px] mb-[120px] xl:my-40"
@@ -228,7 +228,7 @@ const BlogPage: FC<BlogPageProps> & {
         */}
 
         <div>
-          {currentArticleMeta?.category ? (
+          {blogMeta?.category ? (
             <ArticleSimilarPosts
               sectionTitle="Similar Articles"
               similarArticles={similarArticles}

--- a/src/pages/blog/index.tsx
+++ b/src/pages/blog/index.tsx
@@ -50,9 +50,12 @@ const BlogIndexPage: FC<BlogIndexPageProps> & {
   return (
     <>
       <PageHead
-        pageTitle="Blog | Instill AI"
-        pageDescription=""
         pageType="main"
+        pageTitle="Blog | Instill AI"
+        pageDescription={null}
+        commitMeta={null}
+        currentArticleMeta={null}
+        additionMeta={null}
       />
       <ContentContainer
         margin="my-[120px] xl:my-40"

--- a/src/pages/career/[slug].tsx
+++ b/src/pages/career/[slug].tsx
@@ -138,6 +138,9 @@ const CareerPositionPage: FC<CareerPositionPageProps> & {
         pageTitle={`${position.name} | Instill AI`}
         pageDescription="We're on a mission to make Al highly accessible to everyone. Join us and make a dent in the universe!"
         pageType="main"
+        additionMeta={null}
+        currentArticleMeta={null}
+        commitMeta={null}
       />
       <ContentContainer
         margin="my-[120px] xl:my-40"

--- a/src/pages/career/index.tsx
+++ b/src/pages/career/index.tsx
@@ -99,9 +99,12 @@ const CareerPage: FC<CareerPageProps> & {
   return (
     <>
       <PageHead
+        pageType="main"
         pageTitle="Career | Instill AI"
         pageDescription="We're on a mission to make Al highly accessible to everyone. Join us and make a dent in the universe!"
-        pageType="main"
+        additionMeta={null}
+        commitMeta={null}
+        currentArticleMeta={null}
       />
       <ContentContainer
         margin="my-[120px] xl:my-40"

--- a/src/pages/docs/[...path].tsx
+++ b/src/pages/docs/[...path].tsx
@@ -159,6 +159,8 @@ const DocsPage: FC<DocsPageProps> & {
             <meta name="docsearch:version" content="3.0.0" />
           </>
         }
+        currentArticleMeta={null}
+        commitMeta={null}
       />
       <div className="grid grid-cols-8">
         <div className="col-span-8 px-6 xl:col-span-6 xl:px-8 max:px-16">

--- a/src/pages/get-access.tsx
+++ b/src/pages/get-access.tsx
@@ -19,9 +19,12 @@ const GetEarlyAccessPage: FC & {
   return (
     <>
       <PageHead
+        pageType="main"
         pageTitle="Get early access | Instill AI"
         pageDescription=" We're now in private alpha. Join as a design partner to adopt AI for unstructured data in your company."
-        pageType="main"
+        additionMeta={null}
+        commitMeta={null}
+        currentArticleMeta={null}
       />
       <ContentContainer
         margin="my-[120px] xl:my-40"

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -177,9 +177,12 @@ const HomePage: FC<HomePageProps> & {
   return (
     <>
       <PageHead
+        pageType="main"
         pageTitle="Instill AI"
         pageDescription="Empower modern data stack, tapping the value of unstructured data with our open source community."
-        pageType="main"
+        additionMeta={null}
+        commitMeta={null}
+        currentArticleMeta={null}
       />
       <div className="flex flex-col">
         <div className="mx-auto flex w-full max-w-[1127px] flex-col px-4 xl:px-0">

--- a/src/pages/newsletter.tsx
+++ b/src/pages/newsletter.tsx
@@ -105,9 +105,12 @@ const NewsletterArchivePage: FC<NewsletterArchivePageProps> & {
   return (
     <>
       <PageHead
+        pageType="main"
         pageTitle="Newsletter Archive | Instill AI"
         pageDescription="Instill AI newsletter archive"
-        pageType="main"
+        additionMeta={null}
+        commitMeta={null}
+        currentArticleMeta={null}
       />
       <ContentContainer
         margin="my-[120px] xl:my-40"

--- a/src/pages/tutorials/[...path].tsx
+++ b/src/pages/tutorials/[...path].tsx
@@ -40,7 +40,7 @@ type TutorialPageProps = {
   headers: RightSidebarProps["headers"];
   tutorials: TutorialMeta[];
   commitMeta: Nullable<CommitMeta>;
-  currentTutorialMeta: Nullable<TutorialMeta>;
+  tutorialMeta: Nullable<TutorialMeta>;
 };
 
 export const getStaticPaths: GetStaticPaths = async () => {
@@ -124,8 +124,7 @@ export const getStaticProps: GetStaticProps<TutorialPageProps> = async ({
       headers,
       tutorials,
       commitMeta,
-      currentTutorialMeta:
-        tutorials.find((e) => e.slug === relativePath) || null,
+      tutorialMeta: tutorials.find((e) => e.slug === relativePath) || null,
     },
   };
 };
@@ -136,42 +135,39 @@ type GetLayOutProps = {
 
 const TutorialPage: FC<TutorialPageProps> & {
   getLayout?: FC<GetLayOutProps>;
-} = ({ mdxSource, commitMeta, headers, tutorials, currentTutorialMeta }) => {
+} = ({ mdxSource, commitMeta, headers, tutorials, tutorialMeta }) => {
   const { icon, label } = getAiTaskIconAndLabel({
-    aiTask: currentTutorialMeta?.aiTask || null,
+    aiTask: tutorialMeta?.aiTask || null,
   });
 
   const [articleContainerRef, articleContainerDimension] =
     useElementDimension();
 
   const similarTutorials = useMemo(() => {
-    if (!currentTutorialMeta) return [];
+    if (!tutorialMeta) return [];
 
     return tutorials
       .filter(
         (e) =>
-          e.useCase === currentTutorialMeta.useCase &&
-          e.title !== currentTutorialMeta.title
+          e.useCase === tutorialMeta.useCase && e.title !== tutorialMeta.title
       )
       .sort(
         (a, b) =>
           new Date(b.publishedOn).getTime() - new Date(a.publishedOn).getTime()
       );
-  }, [tutorials, currentTutorialMeta]);
+  }, [tutorials, tutorialMeta]);
 
   return (
     <>
       <PageHead
         pageTitle={
-          currentTutorialMeta
-            ? `${currentTutorialMeta.title} | Tutorial`
-            : "Tutorial"
+          tutorialMeta ? `${tutorialMeta.title} | Tutorial` : "Tutorial"
         }
-        pageDescription={
-          currentTutorialMeta ? currentTutorialMeta.description : ""
-        }
-        pageType="main"
-        ogImage={`${process.env.NEXT_PUBLIC_BASE_URL}${mdxSource.frontmatter?.themeImgThumbnailSrc}`}
+        pageDescription={tutorialMeta ? tutorialMeta.description : ""}
+        pageType="tutorial"
+        currentArticleMeta={tutorialMeta}
+        commitMeta={commitMeta}
+        additionMeta={null}
       />
       <ContentContainer
         margin="mt-[60px] mb-[120px] xl:my-40"
@@ -183,20 +179,16 @@ const TutorialPage: FC<TutorialPageProps> & {
             marginBottom="mb-5 xl:mb-10"
           />
           <TutorialPipelineLabel
-            aiTask={currentTutorialMeta?.aiTask || null}
+            aiTask={tutorialMeta?.aiTask || null}
             icon={icon}
             label={label}
-            sourceConnector={currentTutorialMeta?.sourceConnector || null}
-            destinationConnector={
-              currentTutorialMeta?.destinationConnector || null
-            }
+            sourceConnector={tutorialMeta?.sourceConnector || null}
+            destinationConnector={tutorialMeta?.destinationConnector || null}
             marginBottom="mb-2"
           />
           <PageHero
-            headline={currentTutorialMeta ? currentTutorialMeta.title : ""}
-            subHeadline={
-              currentTutorialMeta ? currentTutorialMeta.description : ""
-            }
+            headline={tutorialMeta ? tutorialMeta.title : ""}
+            subHeadline={tutorialMeta ? tutorialMeta.description : ""}
             headerFontFamily="font-sans"
             marginBottom="mb-3"
             width="max-w-[1127px]"
@@ -206,22 +198,16 @@ const TutorialPage: FC<TutorialPageProps> & {
             headerUppercase={false}
           />
           <ArticlePublishInfo
-            author={currentTutorialMeta ? currentTutorialMeta.author : ""}
-            authorAvatarSrc={
-              currentTutorialMeta ? currentTutorialMeta.authorAvatarSrc : ""
-            }
-            publishedOn={
-              currentTutorialMeta ? currentTutorialMeta.publishedOn : ""
-            }
-            authorGitHubUrl={
-              currentTutorialMeta ? currentTutorialMeta.authorGitHubUrl : ""
-            }
+            author={tutorialMeta ? tutorialMeta.author : ""}
+            authorAvatarSrc={tutorialMeta ? tutorialMeta.authorAvatarSrc : ""}
+            publishedOn={tutorialMeta ? tutorialMeta.publishedOn : ""}
+            authorGitHubUrl={tutorialMeta ? tutorialMeta.authorGitHubUrl : ""}
             marginBottom="mb-10"
           />
           <ArticleThemeImage
-            imgSrc={currentTutorialMeta?.themeImgSrc || null}
+            imgSrc={tutorialMeta?.themeImgSrc || null}
             placeholderColor={
-              currentTutorialMeta?.placeholderColor || "bg-instillBlue50"
+              tutorialMeta?.placeholderColor || "bg-instillBlue50"
             }
             marginBottom="mb-20 xl:mb-40"
           />
@@ -249,7 +235,7 @@ const TutorialPage: FC<TutorialPageProps> & {
         */}
 
         <div>
-          {currentTutorialMeta?.useCase ? (
+          {tutorialMeta?.useCase ? (
             <ArticleSimilarPosts
               sectionTitle="Similar Articles"
               similarArticles={similarTutorials}

--- a/src/pages/tutorials/index.tsx
+++ b/src/pages/tutorials/index.tsx
@@ -102,9 +102,12 @@ const TutorialIndexPage: FC<TutorialIndexPageProps> & {
   return (
     <>
       <PageHead
-        pageTitle="Tutorial | Instill AI"
-        pageDescription=""
         pageType="main"
+        pageTitle="Tutorial | Instill AI"
+        pageDescription={null}
+        commitMeta={null}
+        currentArticleMeta={null}
+        additionMeta={null}
       />
       <ContentContainer
         margin="my-[120px] xl:my-40"

--- a/src/types/instill.ts
+++ b/src/types/instill.ts
@@ -91,3 +91,9 @@ export type TutorialPlaceholderColor =
   | "bg-instillGreen50"
   | "bg-instillNeonBlue50"
   | "bg-instillYellow50";
+
+export type PageMeta = {
+  pageTitle: string;
+  siteName: string;
+  pageDescription?: string;
+};


### PR DESCRIPTION
Because

- we want to have richer open graph meta data

This commit

- add `Written by` label, `Category` label, `article:publisher`, `article:published_time`, `article:tag`, `article:modified_time` for blog
- - add `Written by` label, `Use Case` label, `article:publisher`, `article:published_time`, `article:tag`, `article:modified_time` for tutorial
