### PR TITLE
docs(import-models,core-concepts): add text to image local model guideline

### DIFF
--- a/docs/core-concepts/ai-task.mdx
+++ b/docs/core-concepts/ai-task.mdx
@@ -429,6 +429,20 @@ with open(filename, 'wb') as f:
 
 🔮 [Stable Diffusion v2.1](https://github.com/instill-ai/model-diffusion-dvc)
 
+:::info{type=tip}
+
+Importing the [Stable Diffusion v2.1](https://github.com/instill-ai/model-diffusion-dvc) from GitHub will take a while. Alternatively, you can download the model locally as a one-time effort.
+
+**Step 1**: Download **Stable Diffusion v2.1 CPU** sample model.
+
+```bash
+curl -o diffusion.zip  https://artifacts.instill.tech/vdp/sample-models/diffusion.zip
+```
+
+**Step2**: Refer to the guideline on **importing local models via [no-code](/docs/import-models/local#no-code-setup) or [low-code](/docs/import-models/local#low-code-setup)** to import the downloaded model.
+
+:::
+
 ## Text generation
 
 Text generation is a Generative AI task to generate new text from text inputs.

--- a/docs/core-concepts/ai-task.mdx
+++ b/docs/core-concepts/ai-task.mdx
@@ -7,7 +7,7 @@ description: "Standardise structured outputs for AI tasks the open-source unstru
 
 The goal of VDP is to streamline the end-to-end unstructured data flow, with the _transform_ component being able to flexibly import AI models to process unstructured data for a specific task for Vision, Language and more.
 
-Intrigued? Refer to [Prepare Models](/docs/prepare-models/overview) to learn about how to prepare your models for AI tasks supported by VDP.
+Intrigued? Refer to [Import Models](/docs/import-models/overview) on how to use the following available off-the-shelf models and [Prepare Models](/docs/prepare-models/overview) on how to prepare custom models for AI tasks supported by VDP.
 
 ## Standardise AI tasks
 

--- a/docs/import-models/local.mdx
+++ b/docs/import-models/local.mdx
@@ -33,8 +33,8 @@ Currently, VDP supports importing models from
 
 The `Local` model definition accepts a `.zip` file that contains all files required for a model to be deployed.
 
-**Step 1: Download sample model data**
-In this case, we use the object detection model [YOLOv4](https://github.com/AlexeyAB/darknet). Let's download and extract the contents of the sample data.
+**Step 1: Download sample model**
+In this case, we use the object detection model [YOLOv4](https://github.com/AlexeyAB/darknet). Let's download and extract the contents of the sample model.
 
 ```shellscript
 # Create a folder

--- a/docs/import-models/local.mdx
+++ b/docs/import-models/local.mdx
@@ -163,7 +163,7 @@ Since a local model has no version control, when the model is successfully impor
 1. Send a HTTP request to the VDP `model-backend` to import a local model.
 
 ```shellscript cURL
-curl -X POST http://localhost:8080/v1alpha/models:multipart \
+curl -X POST http://localhost:8080/v1alpha/models/multipart \
 --form 'id="yolov4"' \
 --form 'model_definition="model-definitions/local"' \
 --form 'content=@"yolov4.zip"'


### PR DESCRIPTION
Because

- users can import Text to Image models from locally

This commit

- add how to import the stable diffusion v2.1 from locally
