### PR TITLE
docs(deployment): add deployment chapter

### DIFF
--- a/content.config.tsx
+++ b/content.config.tsx
@@ -50,6 +50,24 @@ const SIDEBAR: Sidebar = {
         ],
       },
       {
+        text: "Deployment",
+        collapsible: true,
+        items: [
+          {
+            text: "Overview",
+            link: "/docs/deployment/overview",
+          },
+          {
+            text: "Docker Compose",
+            link: "/docs/deployment/docker-compose",
+          },
+          {
+            text: "Kubernetes using Helm",
+            link: "/docs/deployment/kubernetes-using-helm",
+          },
+        ],
+      },
+      {
         text: "Core Concepts",
         collapsible: true,
         items: [

--- a/docs/core-concepts/ai-task.mdx
+++ b/docs/core-concepts/ai-task.mdx
@@ -25,7 +25,7 @@ At the moment, VDP defines the data interface for popular tasks:
 - **Instance Segmentation** - detect, localise and delineate multiple objects in images
 - **Semantic Segmentation** - classify image pixels into predefined categories
 - **Text to Image** - generate images from input text prompts
-- **Text generation** - generate texts from input text prompts
+- **Text Generation** - generate texts from input text prompts
 - The list is growing ... 🌱
 
 The above tasks focus on analysing and understanding the content of data in the same way as human does.
@@ -455,15 +455,15 @@ curl https://artifacts.instill.tech/vdp/sample-models/stable-diffusion-1-5-fp32-
 
 :::
 
-## Text generation
+## Text Generation
 
-Text generation is a Generative AI task to generate new text from text inputs.
+Text Generation is a Generative AI task to generate new text from text inputs.
 Generally, the task takes incomplete text prompts as the input, and produces new text based on the prompts.
 The task can fill in incomplete sentences or even generate full stories given the first words.
 
 <ZoomableImg
   src="/docs-assets/core-concepts/ai-task-text-generation.svg"
-  alt="Text generation task"
+  alt="Text Generation task"
 />
 
 ```json

--- a/docs/deployment/docker-compose.mdx
+++ b/docs/deployment/docker-compose.mdx
@@ -1,0 +1,39 @@
+---
+title: "Docker Compose"
+lang: "en-US"
+draft: false
+description: "Learn about how to deploy open-source VDP https://github.com/instill-ai/vdp using Docker Compose"
+---
+
+Docker Compose is the most straightforward way to have a setup for VDP in a local machine or remote instances.
+
+:::info{type=info}
+Instructions in this page have been tested on macOS and Ubuntu 22.04.
+:::
+
+## Setup
+
+Make sure that Docker Engine and Docker Compose plugin have been installed on your workstation (see the official [instructions](https://docs.docker.com/compose/install)).
+
+On your workstation, run:
+
+```shellscript
+git clone https://github.com/instill-ai/vdp.git && cd vdp
+make all
+```
+
+Once all services are up and running, the `api-gateway` can be accessed at [http://localhost:8080](http://localhost:8080)
+and the `console` at [http://localhost:3000](http://localhost:3000).
+
+## Shutdown
+
+To shutdown and clean up all VDP resources, run
+
+```shellscript
+make down
+```
+
+## Troubleshooting
+
+If you encounter any issues, please [create an issue on GitHub](https://github.com/instill-ai/vdp/issues)
+or come to our [Discord](https://discord.gg/sevxWsqpGh) channel **#ask-for-help**. The community loves to help!

--- a/docs/deployment/docker-compose.mdx
+++ b/docs/deployment/docker-compose.mdx
@@ -5,7 +5,7 @@ draft: false
 description: "Learn about how to deploy open-source VDP https://github.com/instill-ai/vdp using Docker Compose"
 ---
 
-Docker Compose is the most straightforward way to have a setup for VDP in a local machine or remote instances.
+Docker Compose is the most straightforward way to setup VDP in local machines or remote instances.
 
 :::info{type=info}
 Instructions in this page have been tested on macOS and Ubuntu 22.04.

--- a/docs/deployment/kubernetes-using-helm.mdx
+++ b/docs/deployment/kubernetes-using-helm.mdx
@@ -15,7 +15,7 @@ VDP currently supports deploying on local Kubernetes.
 
 We recommend using one of the local Kubernetes solutions:
 
-- [Docker Desktop (macOS)](https://docs.docker.com/desktop/kubernetes)
+- [Docker Desktop (macOS)](https://docs.docker.com/desktop/) with [Kubernetes](https://docs.docker.com/desktop/kubernetes) enabled
 - [minikube](https://minikube.sigs.k8s.io/docs/start)
 - [kind](https://kind.sigs.k8s.io)
 
@@ -58,7 +58,7 @@ to see the charts:
 
 ```bash
 NAME            CHART VERSION   APP VERSION     DESCRIPTION
-instill/vdp     0.1.0-alpha     0.6.0-alpha     Versatile Data Pipeline (VDP) empowers the mode...
+instill/vdp     <chart-version> <app-version>   Versatile Data Pipeline (VDP) empowers the mode...
 ```
 
 :::info{type=info}
@@ -70,7 +70,19 @@ The VDP and its Helm chart are still in a pre-release Alpha version, so the `--d
 To install the chart:
 
 ```bash
-helm install <my-release-name> instill/vdp --devel --namespace <my-namespace> --create-namespace
+helm install vdp instill/vdp --devel --namespace vdp --create-namespace
+```
+
+And Get the application URL by running these commands and visit VDP via `port-forward`:
+
+```bash
+export APIGATEWAY_POD_NAME=$(kubectl get pods --namespace vdp -l "app.kubernetes.io/component=api-gateway,app.kubernetes.io/instance=vdp" -o jsonpath="{.items[0].metadata.name}")
+export APIGATEWAY_CONTAINER_PORT=$(kubectl get pod --namespace vdp $APIGATEWAY_POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+export CONSOLE_POD_NAME=$(kubectl get pods --namespace vdp -l "app.kubernetes.io/component=console,app.kubernetes.io/instance=vdp" -o jsonpath="{.items[0].metadata.name}")
+export CONSOLE_CONTAINER_PORT=$(kubectl get pod --namespace vdp $CONSOLE_POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+echo "Visit the api-gateway http://localhost:8080 and console http://localhost:3000 by:"
+echo "kubectl --namespace vdp port-forward $APIGATEWAY_POD_NAME 8080:${APIGATEWAY_CONTAINER_PORT}"
+echo "kubectl --namespace vdp port-forward $CONSOLE_POD_NAME 3000:${CONSOLE_CONTAINER_PORT}"
 ```
 
 ## Uninstall
@@ -78,14 +90,14 @@ helm install <my-release-name> instill/vdp --devel --namespace <my-namespace> --
 To uninstall the chart:
 
 ```bash
-helm uninstall <my-release-name> --namespace <my-namespace>
+helm uninstall vdp --namespace vdp
 ```
 
 , and further clean up all VDP-related persistent volumes:
 
 ```bash
-kubectl delete pvc --all -n <my-namespace>
-kubectl delete namespace <my-namespace>
+kubectl delete pvc --all -n vdp
+kubectl delete namespace vdp
 ```
 
 ## Troubleshooting

--- a/docs/deployment/kubernetes-using-helm.mdx
+++ b/docs/deployment/kubernetes-using-helm.mdx
@@ -1,0 +1,94 @@
+---
+title: "Kubernetes Using Helm"
+lang: "en-US"
+draft: false
+description: "Learn about how to deploy open-source VDP https://github.com/instill-ai/vdp in Kubernetes using Helm"
+---
+
+Kubernetes offers an elastic way of managing VDP to persist the services and scale resources horizontally and vertically.
+
+## Setup
+
+VDP currently supports deploying on local Kubernetes.
+
+### Cluster setup
+
+We recommend using one of the local Kubernetes solutions:
+
+- [Docker Desktop (macOS)](https://docs.docker.com/desktop/kubernetes)
+- [minikube](https://minikube.sigs.k8s.io/docs/start)
+- [kind](https://kind.sigs.k8s.io)
+
+### `kubectl` setup
+
+Make sure the Kubernetes CLI tool `kubectl` has been installed in your environment.
+If not, please follow the official [instructions](https://kubernetes.io/docs/tasks/tools/#kubectl) to install.
+
+Make sure `kubectl` is configured to connect to the local cluster by
+
+```bash
+kubectl use-context <cluster-name>
+```
+
+### Helm setup
+
+Make sure Helm has been installed in your environment. If not, please follow the official [instructions](https://helm.sh/docs/intro/install) to install.
+
+Check out the VDP Helm repository on [ArtifactHub](https://artifacthub.io/packages/helm/instill/vdp).
+
+To add VDP Helm repository, simply run
+
+```bash
+helm repo add instill https://helm.instill.tech
+```
+
+, and
+
+```bash
+helm repo update
+```
+
+You can then run
+
+```bash
+helm search repo vdp --devel
+```
+
+to see the charts:
+
+```bash
+NAME            CHART VERSION   APP VERSION     DESCRIPTION
+instill/vdp     0.1.0-alpha     0.6.0-alpha     Versatile Data Pipeline (VDP) empowers the mode...
+```
+
+:::info{type=info}
+The VDP and its Helm chart are still in a pre-release Alpha version, so the `--devel` flag is necessary for the access of Helm charts.
+:::
+
+## Install
+
+To install the chart:
+
+```bash
+helm install <my-release-name> instill/vdp --devel --namespace <my-namespace> --create-namespace
+```
+
+## Uninstall
+
+To uninstall the chart:
+
+```bash
+helm uninstall <my-release-name> --namespace <my-namespace>
+```
+
+, and further clean up all VDP-related persistent volumes:
+
+```bash
+kubectl delete pvc --all -n <my-namespace>
+kubectl delete namespace <my-namespace>
+```
+
+## Troubleshooting
+
+If you encounter any issues, please [create an issue on GitHub](https://github.com/instill-ai/vdp/issues)
+or come to our [Discord](https://discord.gg/sevxWsqpGh) channel **#ask-for-help**. The community loves to help!

--- a/docs/deployment/overview.mdx
+++ b/docs/deployment/overview.mdx
@@ -1,0 +1,14 @@
+---
+title: "Deployment Overview"
+lang: "en-US"
+draft: false
+description: "Learn about how to deploy open-source VDP https://github.com/instill-ai/vdp"
+---
+
+Versatile Data Pipeline (VDP) provides AI and data practitioners a infrastructure to build up complex pipelines to
+concatenate data connectors and AI models to process unstructured data.
+
+VDP currently supports deployment via:
+
+- [Docker Compose](/docs/deployment/docker-compose)
+- [Kubernetes using Helm](/docs/deployment/kubneretes-using-helm)

--- a/docs/deployment/overview.mdx
+++ b/docs/deployment/overview.mdx
@@ -5,10 +5,10 @@ draft: false
 description: "Learn about how to deploy open-source VDP https://github.com/instill-ai/vdp"
 ---
 
-Versatile Data Pipeline (VDP) provides AI and data practitioners a infrastructure to build up complex pipelines to
-concatenate data connectors and AI models to process unstructured data.
+Versatile Data Pipeline (VDP) provides AI and data practitioners an infrastructure to build up complex pipelines to
+extract unstructured data from data connectors and process it with AI models.
 
 VDP currently supports deployment via:
 
 - [Docker Compose](/docs/deployment/docker-compose)
-- [Kubernetes using Helm](/docs/deployment/kubneretes-using-helm)
+- [Kubernetes using Helm](/docs/deployment/kubernetes-using-helm)

--- a/docs/development/setup-local-development.mdx
+++ b/docs/development/setup-local-development.mdx
@@ -15,7 +15,7 @@ Services are associated with profiles through the `profiles` attribute, which ta
 A service will be started only if one of its profile names is activated. A service without `profiles` will always be started.
 :::
 
-VDP assigns five different profile names:
+VDP assigns seven different profile names:
 
 - `console` - start all the dependent services for [`console`](https://github.com/instill-ai/console)
 - `mgmt` - start all the dependent services for [`mgmt-backend`](https://github.com/instill-ai/mgmt-backend)

--- a/docs/start-here/configuration.mdx
+++ b/docs/start-here/configuration.mdx
@@ -55,7 +55,7 @@ Without setting `DOMAIN`, the default domain is `localhost`.
 
 ## Anonymised Usage Collection
 
-To help us better understand how VDP is used and can be improved, VDP collects and reports _Anonymised_ usage statistics.
+To help us better understand how VDP is used and can be improved, VDP collects and reports _anonymised_ usage statistics.
 
 ### What data is collected
 
@@ -122,4 +122,4 @@ This will disable the VDP usage collection for the entire project.
 
 ## Acknowledgements
 
-Our Anonymised usage collection were inspired by KrakenD's [How we built our telemetry service](https://www.krakend.io/blog/building-a-telemetry-service/) and would love to acknowledge that their design has helped us to bootstrap our usage collection project.
+Our anonymised usage collection were inspired by KrakenD's [How we built our telemetry service](https://www.krakend.io/blog/building-a-telemetry-service/) and would love to acknowledge that their design has helped us to bootstrap our usage collection project.

--- a/docs/start-here/getting-started.mdx
+++ b/docs/start-here/getting-started.mdx
@@ -54,6 +54,10 @@ make down
 
 Just visit the [demo website](https://demo.instill.tech) to try out VDP.
 
+### Deploy on Kubernetes
+
+Please follow the [instructions](/docs/deployment/kubernetes-using-helm) to deploy VDP on local Kubernetes using Helm.
+
 ## Start building with VDP
 
 If this is your first time setting up VDP, access the Console (http://localhost:3000) and you should see the onboarding page. Please enter your email and you are all set!

--- a/docs/start-here/roadmap.mdx
+++ b/docs/start-here/roadmap.mdx
@@ -10,7 +10,7 @@ VDP is under rapid development. Our team is pushing new features every day to me
 ## 2022 Q4
 
 - ✅ [api-gateway] Add API Gateway / Reverse Proxy
-- 🎯 [vdp] Support VDP Kubernetes deployment
+- ✅ [vdp] Support VDP Kubernetes deployment
 
 ## 2023 Q1
 


### PR DESCRIPTION
Because

- we have multiple deployment approaches now and each requires a document to detail

This commit

- add deployment documents
- update roadmap
- fix several typos
