### PR TITLE
docs(deployment): refactor how to install VDP via Helm

### DIFF
--- a/docs/deployment/kubernetes-using-helm.mdx
+++ b/docs/deployment/kubernetes-using-helm.mdx
@@ -73,16 +73,15 @@ To install the chart:
 helm install vdp instill/vdp --devel --namespace vdp --create-namespace
 ```
 
-And Get the application URL by running these commands and visit VDP via `port-forward`:
+And visit the `api-gateway` ([http://localhost:8080](http://localhost:8080)) and Console ([http://localhost:3000](http://localhost:3000)) by port forwarding:
 
 ```bash
 export APIGATEWAY_POD_NAME=$(kubectl get pods --namespace vdp -l "app.kubernetes.io/component=api-gateway,app.kubernetes.io/instance=vdp" -o jsonpath="{.items[0].metadata.name}")
 export APIGATEWAY_CONTAINER_PORT=$(kubectl get pod --namespace vdp $APIGATEWAY_POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
 export CONSOLE_POD_NAME=$(kubectl get pods --namespace vdp -l "app.kubernetes.io/component=console,app.kubernetes.io/instance=vdp" -o jsonpath="{.items[0].metadata.name}")
 export CONSOLE_CONTAINER_PORT=$(kubectl get pod --namespace vdp $CONSOLE_POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
-echo "Visit the api-gateway http://localhost:8080 and console http://localhost:3000 by:"
-echo "kubectl --namespace vdp port-forward $APIGATEWAY_POD_NAME 8080:${APIGATEWAY_CONTAINER_PORT}"
-echo "kubectl --namespace vdp port-forward $CONSOLE_POD_NAME 3000:${CONSOLE_CONTAINER_PORT}"
+kubectl --namespace vdp port-forward $APIGATEWAY_POD_NAME 8080:${APIGATEWAY_CONTAINER_PORT} &
+kubectl --namespace vdp port-forward $CONSOLE_POD_NAME 3000:${CONSOLE_CONTAINER_PORT} &
 ```
 
 ## Uninstall


### PR DESCRIPTION
Because

- we want to refactor the Kubernetes deployment docs to be clearer

This commit

- refactor Kubernetes deployment documentation
