### PR TITLE
docs: refactor deployment doc

### DIFF
--- a/docs/deployment/kubernetes-using-helm.mdx
+++ b/docs/deployment/kubernetes-using-helm.mdx
@@ -9,7 +9,7 @@ Kubernetes offers an elastic way of managing VDP to persist the services and sca
 
 ## Setup
 
-VDP currently supports deploying on local Kubernetes.
+VDP currently supports deploying on Kubernetes.
 
 ### Cluster setup
 


### PR DESCRIPTION
Because

- VDP helm chart can be deployed on Kubernetes, not constrained to local Kubernetes

This commit

- refactor deployment documentation
