### PR TITLE
chore: update the text since k8s is supported

### DIFF
--- a/blog/introducing-vdp.mdx
+++ b/blog/introducing-vdp.mdx
@@ -36,7 +36,7 @@ _We believe VDP is the future for unstructured data ETL, where developers won't 
 
 Our mission is to make VDP the single point of unstructured data integration, so users can sync unstructured data from anywhere into centralised warehouses or applications and focus on gaining insights across all data sources, just like how the modern data stack handles structured data. Check out [highlights](https://www.instill.tech/docs/start-here/getting-started?utm_source=blog&utm_medium=link&utm_campaign=introducing-vdp) and [core concepts](https://www.instill.tech/docs/core-concepts/overview?utm_source=blog&utm_medium=link&utm_campaign=introducing-vdp) if you want to learn more about how VDP works.
 
-To benefit a broader community, we release VDP under the open-source Apache license 2.0. Check it out [here](https://github.com/instill-ai/vdp/blob/main/LICENSE). We've made it easy to get started with VDP on your local machine and Kubernetes (coming soon). Click here to [get started](https://www.instill.tech/docs/start-here/getting-started?utm_source=blog&utm_medium=link&utm_campaign=introducing-vdp).
+To benefit a broader community, we release VDP under the open-source Apache license 2.0. Check it out [here](https://github.com/instill-ai/vdp/blob/main/LICENSE). We've made it easy to get started with VDP on your local machine and Kubernetes. Click here to [get started](https://www.instill.tech/docs/start-here/getting-started?utm_source=blog&utm_medium=link&utm_campaign=introducing-vdp).
 
 If you want to chat about VDP or share your use cases, come and hang out with us in our [Discord community](http://go.instill.tech/4ey9lz).
 

--- a/tutorials/vdp-101-2-quickstart.mdx
+++ b/tutorials/vdp-101-2-quickstart.mdx
@@ -2,7 +2,7 @@
 title: "VDP 101 [2/7] Launch VDP on your local machine"
 lang: "en-US"
 draft: false
-description: "To benefit a broader community, we release VDP under the open-source Apache license 2.0. We've made it easy to get started with VDP on your local machine and Kubernetes (coming soon). "
+description: "To benefit a broader community, we release VDP under the open-source Apache license 2.0. We've made it easy to get started with VDP on your local machines and Kubernetes clusters. "
 aiTask: "Null"
 sourceConnector: "Null"
 destinationConnector: "Null"
@@ -18,7 +18,7 @@ authorGitHubUrl: "https://github.com/bryan107"
 
 In [VDP 101 [1/7] Introduction to VDP](/tutorials/vdp-101-1-introduction), we briefly introduce the high-level concept of VDP.
 To benefit a broader community, we release VDP under the open-source Apache license 2.0.
-Check it out [here](https://github.com/instill-ai/vdp/blob/main/LICENSE). We've made it easy to get started with VDP on your local machine and Kubernetes (coming soon).
+Check it out [here](https://github.com/instill-ai/vdp/blob/main/LICENSE). We've made it easy to get started with VDP on your local machines and Kubernetes clusters.
 
 ## Prerequisites
 


### PR DESCRIPTION
Because

- vdp supports deploying on Kubernetes now

This commit

- remove `coming soon` in Kubernetes related text
