### PR TITLE
docs(tutorial): fix info block in tutorial

### DIFF
--- a/tutorials/vdp-101-4-how-to-trigger-a-sync-pipeline.mdx
+++ b/tutorials/vdp-101-4-how-to-trigger-a-sync-pipeline.mdx
@@ -218,7 +218,7 @@ The HTTP POST request is similar to the **HTTP POST Request**. The only differen
 requests.post(f"{pipeline_backend_base_url}/pipelines/{pipeline_id}/trigger-multipart", files=body)
 ```
 
-<InfoBlock>
+<InfoBlock type="info" title="info">
   For further details of the Python `requests.post()` method, we refer readers
   [here](https://www.w3schools.com/python/ref_requests_post.asp).
 </InfoBlock>


### PR DESCRIPTION
Because

- `pnpm build` will fail since the type and title are missing from the InfoBlock 

This commit

- refactor info block in vdp tutorial
