### PR TITLE
style: section title text space smaller (#339)

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -311,13 +311,13 @@ module.exports = {
           boxShadow: "0px 0px 0px 3px #FFFCE3",
         },
         ".word-spacing-tight": {
-          wordSpacing: "-0.25rem",
+          wordSpacing: "-0.4rem",
         },
         ".word-spacing-tighter": {
-          wordSpacing: "-0.5rem",
+          wordSpacing: "-0.8rem",
         },
         ".word-spacing-super-tight": {
-          wordSpacing: "-1rem",
+          wordSpacing: "-1.2rem",
         },
         ".word-spacing-normal": {
           wordSpacing: "0rem",


### PR DESCRIPTION
will close this issue [https://github.com/instill-ai/instill.tech/issues/339](https://github.com/instill-ai/instill.tech/issues/339)

Because

- title text space between words was bit more.

This commit

- title text space refactored to smaller gap between the word
