### PR TITLE
docs: fix typos in VDP 101 tutorials

### DIFF
--- a/tutorials/vdp-101-2-quickstart.mdx
+++ b/tutorials/vdp-101-2-quickstart.mdx
@@ -60,7 +60,7 @@ git clone https://github.com/instill-ai/vdp.git && cd vdp
 make all
 ```
 
-The installation may take a while. Have a cup of tea 🍵. Once the services are up, WHALA, the Console UI is ready to go at [http://localhost:3000](http://localhost:3000/).
+The installation may take a while. Have a cup of tea 🍵. Once the services are up, Voilà, the Console UI is ready to go at [http://localhost:3000](http://localhost:3000/).
 
 <InfoBlock type="warning" title="warning">
   ⚠︎ Don't panic if you don't see the Console UI right after `make all`.

--- a/tutorials/vdp-101-4-how-to-trigger-a-sync-pipeline.mdx
+++ b/tutorials/vdp-101-4-how-to-trigger-a-sync-pipeline.mdx
@@ -127,7 +127,7 @@ To check if you got everything ready, run the Python example with the command be
 python sync-http-url.py --api-gateway-url=http://localhost:8080 --pipeline-id=vdp-101-sync --image-url=https://artifacts.instill.tech/imgs/dog.jpg
 ```
 
-WHALA! You just triggered the object detection pipeline **vdp-101-sync**! You should see the detection results shown on the input [dog](https://artifacts.instill.tech/imgs/dog.jpg) image:
+Voilà! You just triggered the object detection pipeline **vdp-101-sync**! You should see the detection results shown on the input [dog](https://artifacts.instill.tech/imgs/dog.jpg) image:
 
 <img
   src="/tutorial-assets/vdp-101/4-how-to-trigger-a-sync-pipeline/dog-example.png"

--- a/tutorials/vdp-101-7-create-trigger-parse-an-async-pipeline.mdx
+++ b/tutorials/vdp-101-7-create-trigger-parse-an-async-pipeline.mdx
@@ -93,7 +93,7 @@ Open your local VDP console ([http://localhost:3000](http://localhost:3000)), an
   alt="Set up destination to the database in Postgres DB."
 />
 
-Suppose you see a green light in front of the `vdp-101-async` pipeline, WHALA! You have just set up an `ASYNC` pipeline.
+Suppose you see a green light in front of the `vdp-101-async` pipeline, Voilà! You have just set up an `ASYNC` pipeline.
 
 ## Trigger the `ASYNC` pipeline
 
@@ -150,7 +150,7 @@ When setting `--pq-host`, users may need to indicate with **actual** IP address 
 $ python process.py --pq-host=< database host > --pq-port=5432 --pq-database=tutorial --pq-username=postgres --pq-password=password --output-filename=output.mp4 --framerate=30
 ```
 
-WHALA! Once everything is processed, you should find a video file `output.mp4` (the same as the youtube video below) created from images in the `outputs` folder with all the images drawn with detected results from triggering the pipeline.
+Voilà! Once everything is processed, you should find a video file `output.mp4` (the same as the youtube video below) created from images in the `outputs` folder with all the images drawn with detected results from triggering the pipeline.
 
 <Youtube id="jokydabr70M" />
 


### PR DESCRIPTION
Because

- we found a few typos need to be addressed in the tutorials

This commit

- Fix the typos
