### PR TITLE
refactor: newsletter archive with ssr and staged fetching tech

### DIFF
--- a/src/components/ui/DynamicPagination.tsx
+++ b/src/components/ui/DynamicPagination.tsx
@@ -1,0 +1,114 @@
+import { useRouter } from "next/router";
+import React from "react";
+
+export type DynamicPaginationProps = {
+  totalCounts: number;
+  currentPage: number;
+  totalPage: number;
+  pages: number[];
+  route: string;
+};
+
+export const getPaginationArrayWithPageScroll = (
+  totalSize: number,
+  sizePerPage: number,
+  paginationSize: number,
+  currPage: number
+) => {
+  const noOfPages = Math.ceil(totalSize / sizePerPage);
+  const array = [];
+  let count = 0;
+  let pageNo = currPage;
+  while (pageNo <= noOfPages && count !== paginationSize) {
+    array.push(pageNo);
+    pageNo = pageNo + 1;
+    count = count + 1;
+  }
+  return array;
+};
+
+export const getPageNumber = (currentPage: number, totalPage: number) => {
+  if (currentPage > totalPage) {
+    return totalPage;
+  }
+  if (currentPage < 1) {
+    return 1;
+  }
+  return currentPage;
+};
+
+export const getTotalPage = (totalCounts: number, perPageCount: number) => {
+  return Math.ceil(totalCounts / perPageCount);
+};
+
+export const DynamicPagination = ({
+  route,
+  totalCounts,
+  currentPage,
+  pages,
+  totalPage,
+}: DynamicPaginationProps) => {
+  const routes = useRouter();
+  return (
+    <div className="flex justify-center">
+      <p
+        onClick={() => {
+          if (currentPage > 1) {
+            routes.push(`${route}`);
+          }
+        }}
+        className="instill-text-body mx-4 flex cursor-pointer text-instillGrey80 hover:text-instillBlue50"
+      >
+        First
+      </p>
+      <p
+        onClick={() => {
+          if (currentPage > 1) {
+            routes.push(`${route}?page=${currentPage - 1}`);
+          }
+        }}
+        className="instill-text-body mx-4 flex cursor-pointer text-instillGrey80 hover:text-instillBlue50"
+      >
+        Prev
+      </p>
+
+      {console.log(pages)}
+
+      {pages?.map((page, index) => (
+        <p
+          key={index}
+          onClick={() => {
+            routes.push(`${route}?page=${page}`);
+          }}
+          className={`instill-text-body mx-4 flex cursor-pointer ${
+            currentPage === page ? "text-instillBlue50" : "text-instillGrey80"
+          } hover:text-instillBlue50`}
+        >
+          {page}
+        </p>
+      ))}
+
+      <p
+        onClick={() => {
+          if (currentPage < totalPage) {
+            routes.push(`${route}?page=${currentPage + 1}`);
+          }
+        }}
+        className="instill-text-body mx-4 flex cursor-pointer text-instillGrey80 hover:text-instillBlue50"
+      >
+        Next
+      </p>
+
+      <p
+        onClick={() => {
+          if (currentPage < totalCounts) {
+            routes.push(`${route}?page=${totalPage}`);
+          }
+        }}
+        className="instill-text-body mx-4 flex cursor-pointer text-instillGrey80 hover:text-instillBlue50"
+      >
+        Last
+      </p>
+    </div>
+  );
+};

--- a/src/components/ui/DynamicPagination.tsx
+++ b/src/components/ui/DynamicPagination.tsx
@@ -72,8 +72,6 @@ export const DynamicPagination = ({
         Prev
       </p>
 
-      {console.log(pages)}
-
       {pages?.map((page, index) => (
         <p
           key={index}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -15,6 +15,13 @@ export { PageHead } from "./PageHead";
 export type { PageHeadProps } from "./PageHead";
 export { PageHero } from "./PageHero";
 export type { PageHeroProps } from "./PageHero";
+export {
+  DynamicPagination,
+  getPaginationArrayWithPageScroll,
+  getPageNumber,
+  getTotalPage,
+} from "./DynamicPagination";
+export type { DynamicPaginationProps } from "./DynamicPagination";
 export { ReactMarkdownWrapper } from "./ReactMarkdownWrapper";
 export type { ReactMarkdownWrapperProps } from "./ReactMarkdownWrapper";
 export { SecureYourSpot } from "./SecureYourSpot";

--- a/src/pages/newsletter.tsx
+++ b/src/pages/newsletter.tsx
@@ -1,5 +1,5 @@
 import { FC, Fragment, ReactElement } from "react";
-import { GetStaticProps } from "next";
+import { GetServerSideProps } from "next";
 import matter from "gray-matter";
 /* eslint-disable-next-line @typescript-eslint/no-var-requires */
 const mailchimp = require("@mailchimp/mailchimp_marketing");
@@ -27,7 +27,7 @@ type GetLayOutProps = {
   page: ReactElement;
 };
 
-export const getStaticProps: GetStaticProps = async () => {
+export const getServerSideProps: GetServerSideProps = async () => {
   // Init mailchimp client
   mailchimp.setConfig({
     apiKey: process.env.NEXT_PUBLIC_MAILCHIMP_API_KEY,
@@ -95,7 +95,6 @@ export const getStaticProps: GetStaticProps = async () => {
     props: {
       campaigns: publicCampaigns,
     },
-    revalidate: 10,
   };
 };
 


### PR DESCRIPTION
will close this issue https://github.com/instill-ai/instill.tech/issues/60

Because

- Right now newsletter archive is SSG, every time we release new newsletter we have to manually re-deploy the whole site. This will cause overhead.

This commit

- Implemented SSR
- Uses pagination to fetch data

example : https://github.com/instill-ai/instill.tech/issues/60#issuecomment-1475307142
