### PR TITLE
docs: add pricing button in nav and open alpha in documentation

### DIFF
--- a/docs/start-here/instill-cloud.mdx
+++ b/docs/start-here/instill-cloud.mdx
@@ -2,18 +2,25 @@
 title: "Instill Cloud"
 lang: "en-US"
 draft: false
-description: ""
+description: "Instill Cloud is a fully-managed public cloud service for VDP. You can try Instill Cloud for free https://console.instill.tech using your email address, Google or GitHub social login."
 ---
 
-☁️ Instill Cloud is a fully-managed public cloud service for VDP (coming soon!).
+☁️ Instill Cloud is a fully-managed public cloud service for VDP.
 
 - Painless setup
 - Maintenance-free infrastructure
 - Production-ready services
 - Start for free, pay as you grow
 
-Access to Instill Cloud is currently by invitation only. If you're interested in the hosting service of VDP,
-[join the waitlist](/get-access/?utm_source=documentation&utm_medium=link) and we'll contact you when we're ready.
+## Instill Cloud is in **Open Alpha**
+
+We need your feedback to help shape the future of Instill Cloud. During the Open Alpha period, we offer
+
+- Free 30-day trial
+- Free pipeline triggers
+- Free access to our pre-trained ML models
+
+👉 [Try Instill Cloud today](https://console.instill.tech/?utm_source=documentation&utm_medium=link&utm_campaign=23q2-instill-cloud-launch) using your email address, Google or GitHub social login.
 
 ## We're open to collaboration
 

--- a/src/pages/pricing.tsx
+++ b/src/pages/pricing.tsx
@@ -39,7 +39,7 @@ const pricingPlans: PricingPlan[] = [
     name: "Starter",
     price: 14.99,
     subTitle: "Open Alpha",
-    subTitleLink: "https://www.instill.tech/docs/start-here/faq#essentials",
+    subTitleLink: "/docs/start-here/instill-cloud",
     description: "For individual or small teams with advanced features",
     features: [
       "FREE compute resource during Open Alpha",


### PR DESCRIPTION
Because

- we want to add pricing button on nav
- we want to explain the benefit of the Open Alpha period

This commit

- add pricing button on nav
- update Instill Cloud page on documentation
- update the Open Alpha link on the pricing page to Instill Cloud page on documentation 
