### PR TITLE
docs(blog,docs,product-website): update Instill Cloud plan info

### DIFF
--- a/blog/unstructured-data-etl.mdx
+++ b/blog/unstructured-data-etl.mdx
@@ -142,7 +142,7 @@ Have a nice day!
 
 ---
 
-_Instill Cloud is currently in Open Alpha, working very closely with early users to build the most effective tool for unstructured data infrastructure. Sign up [here](https://console.instill.tech/?utm_source=blog&utm_medium=link&utm_campaign=unstructured-data-etl) with 30-day free trial._
+_Instill Cloud is currently in Open Alpha, working very closely with early users to build the most effective tool for unstructured data infrastructure. [Sign up for free today](https://console.instill.tech/?utm_source=blog&utm_medium=link&utm_campaign=unstructured-data-etl)._
 
 <CtaButton
   text="🚀 Try Instill Cloud Free"

--- a/blog/why-instill-ai-exists.mdx
+++ b/blog/why-instill-ai-exists.mdx
@@ -78,7 +78,7 @@ If you have read this far, it is likely that we share some experiences or though
 
 ---
 
-_Instill Cloud is currently in open alpha, working very closely with early users to build the most effective tool for unstructured data infrastructure. Sign up [here](https://console.instill.tech/?utm_source=blog&utm_medium=link&utm_campaign=why-instill-ai/exists) with 30-day free trial._
+_Instill Cloud is currently in open alpha, working very closely with early users to build the most effective tool for unstructured data infrastructure. [Sign up for free today](https://console.instill.tech/?utm_source=blog&utm_medium=link&utm_campaign=why-instill-ai/exists)._
 
 <CtaButton
   text="🚀 Try Instill Cloud Free"

--- a/docs/instill-cloud/getting-started.mdx
+++ b/docs/instill-cloud/getting-started.mdx
@@ -14,23 +14,21 @@ description: "Instill Cloud is a fully-managed public cloud service for VDP. You
 
 ## Instill Cloud is in **Open Alpha**
 
-We need your feedback to help shape the future of Instill Cloud. During the Open Alpha period, we offer
-
-- Free 30-day trial
-- Free pipeline triggers
-- Free access to our pre-trained ML models
+Instill Cloud is in **Open Alpha** testing phase - with all features **FREE**. For more information, see the [Pricing](/pricing) page.
+Rest assured that we will never charge you without your consent.
 
 👉 [Try Instill Cloud today](https://console.instill.tech/?utm_source=documentation&utm_medium=link&utm_campaign=23q2-instill-cloud-launch) using your email address, Google or GitHub social login.
-For more information, see the [Pricing](/pricing) page.
+We're adding new features every day and we need your feedback to help shape the future of Instill Cloud.
 
 ## Set up your Instill Cloud account
 
 To use Instill Cloud, set up your account for the first time or log in from [here](https://console.instill.tech/?utm_source=documentation&utm_medium=link&utm_campaign=23q2-instill-cloud-launch).
 
 <InfoBlock type="info" title="info">
-  After signing up, we will send you an email to verify your email. If you have
-  not received the email within a few minutes, please check your spam inbox just
-  to be sure. If it is found in the spam inbox, mark the email as "Not Spam".
+  After signing up with your email address and password, we will send you an
+  email to verify your email. If you have not received the email within a few
+  minutes, please check your spam inbox just to be sure. If it is found in the
+  spam inbox, mark the email as "Not Spam".
 </InfoBlock>
 
 ## What's next?

--- a/docs/vdp/faq.mdx
+++ b/docs/vdp/faq.mdx
@@ -71,9 +71,9 @@ This page curates a list of frequently asked questions from our users, friends, 
     <summary>**How do you make money?**</summary>
 
     We offer fully managed VDP service on **Instill Cloud** to users who want to get all the power of VDP without any hassle.
-    It is currently in Open Alpha and we need your feedback to help shape the future of the service.
-    During Open Alpha, we offer a 30-day trial, free pipeline triggers, and free access to pre-trained ML models.
-    For more information, see the [Pricing](/pricing) page.
+    It is currently in **Open Alpha** testing phase - with all features **FREE**. For more information, see the [Pricing](/pricing) page. Rest assured that we will never charge you without your consent.
+
+    We are adding new features every day and we need your feedback to help shape the future of the service and build Instill Cloud the best it can be.
 
     👉 [Try Instill Cloud free](https://console.instill.tech/?utm_source=documentation&utm_medium=link)
 

--- a/src/components/landing/Faq/Faq.tsx
+++ b/src/components/landing/Faq/Faq.tsx
@@ -105,9 +105,9 @@ In spite of all that, VDP is an open-source project. Everyone is more than welco
                 content: (
                   <FaqContent>
                     {`We offer fully managed VDP service on **Instill Cloud** to users who want to get all the power of VDP without any hassle.
-It is currently in Open Alpha and we need your feedback to help shape the future of the service.
-During Open Alpha, we offer 30-day trial, free pipeline triggers and free access to pre-trained ML models.
-For more information, see the [Pricing](/pricing) page.
+    It is currently in **Open Alpha** testing phase - with all features **FREE**. For more information, see the [Pricing](/pricing) page. Rest assured that we will never charge you without your consent.
+
+    We are adding new features every day and we need your feedback to help shape the future of the service and build Instill Cloud the best it can be.
 
 👉 [Try Instill Cloud free](https://console.instill.tech/?utm_source=documentation&utm_medium=link)`}
                   </FaqContent>

--- a/src/components/landing/Faq/Faq.tsx
+++ b/src/components/landing/Faq/Faq.tsx
@@ -104,10 +104,9 @@ In spite of all that, VDP is an open-source project. Everyone is more than welco
                 header: "How do you make money?",
                 content: (
                   <FaqContent>
-                    {`We offer fully managed VDP service on **Instill Cloud** to users who want to get all the power of VDP without any hassle.
-    It is currently in **Open Alpha** testing phase - with all features **FREE**. For more information, see the [Pricing](/pricing) page. Rest assured that we will never charge you without your consent.
+                    {`We offer fully managed VDP service on **Instill Cloud** to users who want to get all the power of VDP without any hassle. It is currently in **Open Alpha** testing phase - with all features **FREE**. For more information, see the [Pricing](/pricing) page. Rest assured that we will never charge you without your consent.
 
-    We are adding new features every day and we need your feedback to help shape the future of the service and build Instill Cloud the best it can be.
+We are adding new features every day and we need your feedback to help shape the future of the service and build Instill Cloud the best it can be.
 
 👉 [Try Instill Cloud free](https://console.instill.tech/?utm_source=documentation&utm_medium=link)`}
                   </FaqContent>


### PR DESCRIPTION
Because

- Instill Cloud is in Open Alpha testing phase, with all features free. We need to update the corresponding information.

This commit

- update the Instill Cloud information
