### PR TITLE
docs(vdp,development): update configuration and local development

### DIFF
--- a/docs/development/setup-local-development.mdx
+++ b/docs/development/setup-local-development.mdx
@@ -7,7 +7,7 @@ description: "Learn about how to set up the development environment for the unst
 
 VDP is built with the microservice architecture. To develop each service independently,
 we assign [profiles](https://docs.docker.com/compose/profiles) to each service in
-the [`docker-compose.dev.yml`](https://github.com/instill-ai/vdp/blob/main/docker-compose.dev.yml) file in VDP.
+the [`docker-compose.latest.yml`](https://github.com/instill-ai/vdp/blob/main/docker-compose.latest.yml) file in VDP.
 This allows us to selectively enable services for various purposes, e.g., debugging, development.
 
 <InfoBlock type="info" title="info">
@@ -25,19 +25,20 @@ VDP assigns seven different profile names:
 - `model` - start all the dependent services for [`model-backend`](https://github.com/instill-ai/model-backend)
 - `pipeline` - start all the dependent services for [`pipeline-backend`](https://github.com/instill-ai/pipeline-backend)
 - `api-gateway` - start all the dependent services for [`api-gateway`](https://github.com/instill-ai/api-gateway)
+- `controller` - start all the dependent services for [`controller`](https://github.com/instill-ai/controller)
 - `all` - start all services
 
 Use one of the profile name to develop the corresponding service:
 
 ```shellscript
 # In the vdp repository folder
-make build PROFILE=<profile-name>
-make latest PROFILE=<profile-name> ITMODE=true
+make build-latest
+make latest PROFILE=<profile-name> ITMODE_ENABLED=true
 ```
 
-The following guideline shows a specific example of how to develop the `connector-backend`.
+The following guideline shows a specific example of how to develop the `pipeline-backend`.
 
-## Start dependent VDP services for `connector-backend`
+## Start dependent VDP services for `pipeline-backend`
 
 On the local machine, clone the `vdp` repository in your workspace, move to the repository folder, and launch all dependent services:
 
@@ -45,20 +46,20 @@ On the local machine, clone the `vdp` repository in your workspace, move to the 
 # Clone the vdp repository
 git clone https://github.com/instill-ai/vdp.git && cd vdp
 
-# Use profile `connector` to launch all dependent services
-# for `connector-backend` and set ITMODE=true
+# Use profile `pipeline` to launch all dependent services
+# for `pipeline-backend` and set ITMODE_ENABLED=true
 # for local integration test
-make build PROFILE=connector
-make latest PROFILE=connector ITMODE=true
+make build-latest
+make latest PROFILE=pipeline ITMODE_ENABLED=true
 ```
 
-## Run dev `connector-backend`
+## Run dev `pipeline-backend`
 
-Clone the `connector-backend` repository in your workspace and move to the repository folder:
+Clone the `pipeline-backend` repository in your workspace and move to the repository folder:
 
 ```shellscript
-git clone https://github.com/instill-ai/connector-backend.git
-cd connector-backend
+git clone https://github.com/instill-ai/pipeline-backend.git
+cd pipeline-backend
 ```
 
 **Build & run the dev image**
@@ -70,28 +71,27 @@ make dev
 
 Now, you have the Go project set up in the container, in which you can compile and run the binaries together with the integration test in each container shell.
 
-**Start the `connector-backend` server**
+**Start the `pipeline-backend` server**
 
 ```shellscript
-docker exec -it connector-backend /bin/bash
+docker exec -it pipeline-backend /bin/bash
 go run ./cmd/migration
-go run ./cmd/init
 go run ./cmd/main
 ```
 
 **Start the Temporal worker**
 
 ```shellscript
-docker exec -it connector-backend /bin/bash
+docker exec -it pipeline-backend /bin/bash
 go run ./cmd/worker
 ```
 
 **Run the integration test**
 
-During local development, you can run the integration test to make sure your latest `connector-backend` works as intended:
+During local development, you can run the integration test to make sure your latest `pipeline-backend` works as intended:
 
 ```shellscript
-docker exec -it connector-backend /bin/bash
+docker exec -it pipeline-backend /bin/bash
 make integration-test
 ```
 

--- a/docs/vdp/configuration.mdx
+++ b/docs/vdp/configuration.mdx
@@ -17,8 +17,9 @@ All configuration environment variables for each service are prefixed with `CFG_
 Read the default configuration files for a full overview of all supported configuration options of each service:
 [`pipeline-backend`](https://github.com/instill-ai/pipeline-backend/blob/main/config/config.yaml),
 [`connector-backend`](https://github.com/instill-ai/connector-backend/blob/main/config/config.yaml),
-[`model-backend`](https://github.com/instill-ai/model-backend/blob/main/config/config.yaml) and
-[`mgmt-backend`](https://github.com/instill-ai/mgmt-backend/blob/main/config/config.yaml).
+[`model-backend`](https://github.com/instill-ai/model-backend/blob/main/config/config.yaml),
+[`mgmt-backend`](https://github.com/instill-ai/mgmt-backend/blob/main/config/config.yaml) and
+[`controller`](https://github.com/instill-ai/controller/blob/main/config/config.yaml)
 
 ### Configuring VDP service version
 
@@ -26,11 +27,13 @@ Set the environment variable for a specific service to determine which version t
 
 ```shellscript .env
 # Set the version of individual VDP service
-CONSOLE_VERSION=<console-version>
-MGMT_BACKEND_VERSION=<mgmt-backend-version>
+API_GATEWAY_VERSION=<api-gateway-version>
+PIPELINE_BACKEND_VERSION=<pipeline-backend-version>
 CONNECTOR_BACKEND_VERSION=<connector-backend-version>
 MODEL_BACKEND_VERSION=<model-backend-version>
-PIPELINE_BACKEND_VERSION=<pipeline-backend-version>
+MGMT_BACKEND_VERSION=<mgmt-backend-version>
+CONTROLLER_VERSION=<controller-version>
+CONSOLE_VERSION=<console-version>
 
 # Set the version of 3rd party tools
 TRITON_SERVER_VERSION=<triton-server-version>
@@ -38,33 +41,46 @@ REDIS_VERSION=<redis-version>
 POSTGRESQL_VERSION=<postgresql-version>
 TEMPORAL_VERSION=<temporal-version>
 TEMPORAL_UI_VERSION=<temporal-ui-version>
+ELASTICSEARCH_VERSION=<elasticsearch-version>
+ETCD_VERSION=<etcd-version>
 ```
 
 The combination of default versions in `.env` file is fully tested for compatibility.
 Unless you are debugging and testing, updating the default versions in the `.env` file is discouraged.
 
-### Configuring the VDP domain
+### Configuring the VDP API host
 
-Set the domain name to access VDP by overriding the environment variable `DOMAIN`:
+Set the host to access VDP by overriding the environment variable `CONSOLE_BASE_API_GATEWAY_URL_HOST`:
 
 ```shellscript .env
-DOMAIN=<domain-name-to-access-vdp>
+CONSOLE_BASE_API_GATEWAY_URL_HOST=<hostname-to-access-vdp>
 ```
 
-Without setting `DOMAIN`, the default domain is `localhost`.
+By default it is set to `localhost`.
 
 ### Configuring the observability stack
 
 Observability is critical for distributed microservice architecture.
 Through [OpenTelemetry](https://opentelemetry.io/), we can generate, collect and export metrics, logs and traces to help analyse the performance and behaviour of VDP services.
 
-The observability stack is disabled by default. You can enable the stack setting `ENABLE_OBSERVE=true` in the [`.env`](https://github.com/instill-ai/vdp/blob/main/.env) file.
+The observability stack is disabled by default. You can enable the stack setting `OBSERVE_ENABLED=true` in the [`.env`](https://github.com/instill-ai/vdp/blob/main/.env) file.
 The following telemetry tools are supported now:
 
 - [**Jaeger**](https://www.jaegertracing.io/) (`localhost:16686`): OpenTelemetry allows us to export spans to Jaeger. Use Jaeger when you want to debug the complete flow of a request through the VDP services.
 - [**InfluxDB**](https://www.influxdata.com/) (`localhost: 8086`, username:`admin`, password:`password`): detailed metrics are sent to InfluxDB for monitoring, and are imported into the Grafana dashboard
 - [**Grafana**](https://grafana.com/) (`localhost:3002`, username:`admin`, password:`admin`): the Grafana dashboard visualises the metrics to monitor the performance and anomalies of VDP services
 - [**Prometheus**](https://prometheus.io/) (`localhost:9090`): VDP exports metrics like `vdp_pipeline_sync_trigger_counter_total` (total number of triggers from SYNC pipelines) and `vdp_pipeline_async_trigger_counter_total` (total number of triggers from ASYNC pipelines) to Prometheus.
+
+Set the environment variable for a specific telemetry tool to determine which version to use in VDP.
+
+```shellscript .env
+# Set the version of the observability stack
+INFLUXDB_VERSION=<influxdb-version>
+OTEL_COLLECTOR_VERSION=<otel-collector-version>
+JAEGER_VERSION=<jaeger-version>
+PROMETHEUS_VERSION=<prometheus-version>
+GRAFANA_VERSION=<grafana-version>
+```
 
 ## Anonymised Usage Collection
 
@@ -129,7 +145,7 @@ VDP usage collection helps the entire community. We'd appreciate it if you can l
 However, if you want to opt out, you can disable it by overriding the `.env` file:
 
 ```shellscript .env
-DISABLEUSAGE=true
+USAGE_ENABLED=false
 ```
 
 This will disable the VDP usage collection for the entire project.


### PR DESCRIPTION
Because

- we want to keep the docs up-to-date

This commit

- update the configuration env variables
- update the local development example
