### PR TITLE
chore: remove the demo website from our Footer

### DIFF
--- a/src/components/ui/Footer/Footer.tsx
+++ b/src/components/ui/Footer/Footer.tsx
@@ -53,10 +53,6 @@ export const Footer = () => {
         href: "https://github.com/instill-ai/vdp",
       },
       {
-        text: "VDP Demo",
-        href: "https://demo.instill.tech",
-      },
-      {
         text: "Instill Cloud",
         href: "https://console.instill.tech",
       },


### PR DESCRIPTION
Because

- we don't plan to showcase the demo right now

This commit

- remove the demo website from our Footer
