### PR TITLE
chore: update docs

### DIFF
--- a/docs/vdp/ai-connectors/openai.mdx
+++ b/docs/vdp/ai-connectors/openai.mdx
@@ -127,7 +127,7 @@ Example input data for **Text Generation** and **Text Embeddings** task:
 
 ```json
 {
-  "texts": ["..."]
+  "texts": ["Can you prove the existence of God?"]
 }
 ```
 
@@ -135,7 +135,11 @@ Example input data for Speech Recognition task:
 
 ```json
 {
-  "audios": ["<base64 encoded audio>"]
+  "audios": [
+    {
+      "url": "http://englishus.voiceoversamples.com/ENG_US_M_KevinS.mp3"
+    }
+  ]
 }
 ```
 
@@ -150,7 +154,7 @@ Example output data for **Text Generation** and **Speech Recognition** task:
 
 ```json
 {
-  "texts": ["..."]
+  "texts": ["Over the past 32 years, the university of Florida..."]
 }
 ```
 

--- a/docs/vdp/ai-connectors/stability-ai.mdx
+++ b/docs/vdp/ai-connectors/stability-ai.mdx
@@ -116,9 +116,7 @@ Example input data for **Text to Image** and **Image to Image** tasks:
 ```json text-to-image
 {
   "texts": [
-    "prompt1",
-    "prompt2",
-    ...
+    "black dog",
   ],
   "metadata": {
     "cfg_scale": 7.0,


### PR DESCRIPTION
Because

- docs for stability ai and open ai don't have actual data examples

This commit

- adds actual data examples for stability ai and open ai
