### PR TITLE
fix: update docs path for commit Meta

### DIFF
--- a/src/pages/docs/[...path].tsx
+++ b/src/pages/docs/[...path].tsx
@@ -152,7 +152,7 @@ export const getStaticProps: GetStaticProps<DocsPageProps> = async ({
     commitMeta = await getCommitMeta({
       org: "instill-ai",
       repo: "instill.tech",
-      path: "docs/" + relativePath + ".mdx",
+      path: "docs/" + relativePath + "." + locale + ".mdx",
     });
   } catch (err) {
     console.log(err);


### PR DESCRIPTION
Because

- update docs path for commit Meta

This commit

- update docs path for commit Meta
