### PR TITLE
fix: In dark mode the search bar placeholder color not visible

### DIFF
--- a/src/styles/docs.css
+++ b/src/styles/docs.css
@@ -23,7 +23,7 @@
 
 .dark .DocSearch-Button {
   border-radius: 2px !important;
-  background-color: #2b2b2b !important;
+  background-color: #5c5c5c !important;
   column-gap: 20px !important;
   margin: 0px !important;
   padding: 0px 12px !important;


### PR DESCRIPTION
Because

- In dark mode the search bar placeholder color is visible

This commit

- Fixed https://github.com/instill-ai/community/issues/414
