### PR TITLE
Add Feedback link on the Righthandsidebar

### DIFF
--- a/src/components/docs/RightSidebar.tsx
+++ b/src/components/docs/RightSidebar.tsx
@@ -8,9 +8,10 @@ import {
 export type RightSidebarProps = {
   headers: TableOfContentProps["headers"];
   githubEditUrl: ContributeLinksProps["githubEditUrl"];
+  feedbackUrl: ContributeLinksProps["feedbackUrl"];
 };
 
-export const RightSidebar = ({ headers, githubEditUrl }: RightSidebarProps) => {
+export const RightSidebar = ({ headers, githubEditUrl, feedbackUrl }: RightSidebarProps) => {
   return (
     <>
       <style jsx>
@@ -25,6 +26,7 @@ export const RightSidebar = ({ headers, githubEditUrl }: RightSidebarProps) => {
         <div className="flex h-full flex-col overflow-auto">
           {headers.length > 0 ? <TableOfContent headers={headers} /> : null}
           <ContributeLinks githubEditUrl={githubEditUrl} />
+          <ContributeLinks feedbackUrl={feedbackUrl} />
         </div>
       </div>
     </>

--- a/src/components/docs/RightSidebar.tsx
+++ b/src/components/docs/RightSidebar.tsx
@@ -25,8 +25,10 @@ export const RightSidebar = ({ headers, githubEditUrl, feedbackUrl }: RightSideb
       <div className="right-sidebar sticky w-full pr-4">
         <div className="flex h-full flex-col overflow-auto">
           {headers.length > 0 ? <TableOfContent headers={headers} /> : null}
-          <ContributeLinks githubEditUrl={githubEditUrl} />
-          <ContributeLinks feedbackUrl={feedbackUrl} />
+          <ContributeLinks 
+              githubEditUrl={githubEditUrl}
+              feedbackUrl={feedbackUrl} 
+          />
         </div>
       </div>
     </>

--- a/src/components/ui/ArticleRightSidebar.tsx
+++ b/src/components/ui/ArticleRightSidebar.tsx
@@ -25,6 +25,8 @@ export const ArticleRightSidebar = ({
             "https://github.com/instill-ai/instill.tech/edit/main" +
             router.asPath +
             ".mdx"
+          feedbackUrl={
+            "https://github.com/instill-ai/community/issues/new/choose"
           }
         />
       </div>

--- a/src/components/ui/ArticleRightSidebar.tsx
+++ b/src/components/ui/ArticleRightSidebar.tsx
@@ -25,6 +25,7 @@ export const ArticleRightSidebar = ({
             "https://github.com/instill-ai/instill.tech/edit/main" +
             router.asPath +
             ".mdx"
+          }
           feedbackUrl={
             "https://github.com/instill-ai/community/issues/new/choose"
           }

--- a/src/components/ui/ContributeLinks.tsx
+++ b/src/components/ui/ContributeLinks.tsx
@@ -1,8 +1,9 @@
 export type ContributeLinksProps = {
   githubEditUrl: string;
+  feedbackUrl: string;
 };
 
-export const ContributeLinks = ({ githubEditUrl }: ContributeLinksProps) => {
+export const ContributeLinks = ({ githubEditUrl, feedbackUrl }: ContributeLinksProps) => {
   return (
     <div className="flex flex-col">
       <h2 className="mb-4 font-semibold text-instillGrey95 dark:text-instillGrey15">
@@ -23,6 +24,23 @@ export const ContributeLinks = ({ githubEditUrl }: ContributeLinksProps) => {
         </svg>
         <p className="my-auto text-sm text-instillGrey50 group-hover:text-instillBlue50">
           Edit this page
+        </p>
+      </a>
+      <a
+        href={feedbackUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="group flex flex-row gap-x-2.5"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 16 16"
+          className="my-auto h-4 w-4 fill-instillGrey50 group-hover:fill-instillBlue50"
+        >
+          <path d="M12.854.146a.5.5 0 0 0-.707 0L10.5 1.793 14.207 5.5l1.647-1.646a.5.5 0 0 0 0-.708l-3-3zm.646 6.061L9.793 2.5 3.293 9H3.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.207l6.5-6.5zm-7.468 7.468A.5.5 0 0 1 6 13.5V13h-.5a.5.5 0 0 1-.5-.5V12h-.5a.5.5 0 0 1-.5-.5V11h-.5a.5.5 0 0 1-.5-.5V10h-.5a.499.499 0 0 1-.175-.032l-.179.178a.5.5 0 0 0-.11.168l-2 5a.5.5 0 0 0 .65.65l5-2a.5.5 0 0 0 .168-.11l.178-.178z" />
+        </svg>
+        <p className="my-auto text-sm text-instillGrey50 group-hover:text-instillBlue50">
+          Provide feedback for this page
         </p>
       </a>
     </div>

--- a/src/components/ui/ContributeLinks.tsx
+++ b/src/components/ui/ContributeLinks.tsx
@@ -13,7 +13,7 @@ export const ContributeLinks = ({ githubEditUrl, feedbackUrl }: ContributeLinksP
         href={githubEditUrl}
         target="_blank"
         rel="noopener noreferrer"
-        className="group flex flex-row gap-x-2.5 mt-2"
+        className="group flex flex-row gap-x-2.5"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -30,7 +30,7 @@ export const ContributeLinks = ({ githubEditUrl, feedbackUrl }: ContributeLinksP
         href={feedbackUrl}
         target="_blank"
         rel="noopener noreferrer"
-        className="group flex flex-row gap-x-2.5 mt-4"
+        className="group flex flex-row gap-x-2.5 mt-2"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"

--- a/src/components/ui/ContributeLinks.tsx
+++ b/src/components/ui/ContributeLinks.tsx
@@ -13,7 +13,7 @@ export const ContributeLinks = ({ githubEditUrl, feedbackUrl }: ContributeLinksP
         href={githubEditUrl}
         target="_blank"
         rel="noopener noreferrer"
-        className="group flex flex-row gap-x-2.5"
+        className="group flex flex-row gap-x-2.5 mt-2"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -30,7 +30,7 @@ export const ContributeLinks = ({ githubEditUrl, feedbackUrl }: ContributeLinksP
         href={feedbackUrl}
         target="_blank"
         rel="noopener noreferrer"
-        className="group flex flex-row gap-x-2.5"
+        className="group flex flex-row gap-x-2.5 mt-4"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"

--- a/src/pages/docs/[...path].tsx
+++ b/src/pages/docs/[...path].tsx
@@ -270,6 +270,16 @@ const DocsPage: FC<DocsPageProps> & {
             />
           ) : null}
         </aside>
+        <aside className="hidden pb-10 xl:col-span-2 xl:block">
+          {headers ? (
+            <RightSidebar
+              feedbackUrl={
+                "https://github.com/instill-ai/community/issues/new/choose"
+              }
+              headers={headers}
+            />
+          ) : null}
+        </aside>
       </div>
     </>
   );

--- a/src/pages/docs/[...path].tsx
+++ b/src/pages/docs/[...path].tsx
@@ -266,13 +266,6 @@ const DocsPage: FC<DocsPageProps> & {
                 `.${router.locale}` +
                 ".mdx"
               }
-              headers={headers}
-            />
-          ) : null}
-        </aside>
-        <aside className="hidden pb-10 xl:col-span-2 xl:block">
-          {headers ? (
-            <RightSidebar
               feedbackUrl={
                 "https://github.com/instill-ai/community/issues/new/choose"
               }


### PR DESCRIPTION
Because

- It adds "Give feedback" link on every documentation page that will redirect user to create new issue about documentation

This commit

- closes the first part of the issue https://github.com/instill-ai/community/issues/394
