### PR TITLE
chore: update outdated links in product website

### DIFF
--- a/.github/DOCS-CONTRIBUTING.md
+++ b/.github/DOCS-CONTRIBUTING.md
@@ -33,7 +33,7 @@ async redirects() {
 
 There have three content folders and their corresponding page, assets folder.
 
-- Docs folder has nested structure, by default it will accept all kinds of nested structure and compile the path into url. For example. A file in /docs/vdp/getting-started.mdx will be compiled into https://instill.tech/docs/vdp/getting-started.
+- Docs folder has nested structure, by default it will accept all kinds of nested structure and compile the path into url. For example. A file in /docs/v0.4.1-alpha/welcome.mdx will be compiled into https://instill.tech/docs/v0.4.1-alpha/welcome.
 - Blog and tutorials currently only accept **flat** structure. This means it won't accept nested folder strcture likes /tutorial/nested-folder/foo.mdx.
 
 ```
@@ -236,31 +236,24 @@ const SECTIONS: SidebarSections[] = [
   {
     //  <---- this menu will be added to cloud
     text: "Instill Cloud",
+    link: `/docs/${appVersion}/cloud`
     collapsible: true,
     items: [
-      {
-        text: "Getting started",
-        link: "/docs/cloud/getting-started",
+     {
+        text: "CLI",
+        link: `/docs/${appVersion}/core/deployment/cli`,
       },
       {
-        text: "Using Instill Cloud",
-        link: "/docs/cloud/using-instill-cloud",
+        text: "Docker Compose",
+        link: `/docs/${appVersion}/core/deployment/docker-compose`,
+      },
+      {
+        text: "Kubernetes",
+        link: `/docs/${appVersion}/core/deployment/kubernetes-using-helm`,
       },
     ],
-    appType: "cloud",
-  },
-  {
-    //  <---- this menu will be added to vdp
-    text: "VDP",
-    collapsible: true,
-    items: [
-      { text: "Getting started", link: "/docs/vdp/getting-started" },
-      { text: "Configuration", link: "/docs/vdp/configuration" },
-      { text: "Roadmap", link: "/docs/vdp/roadmap" },
-      { text: "License", link: "/docs/vdp/license" },
-      { text: "FAQ", link: "/docs/vdp/faq" },
-    ],
-    appType: "vdp",
+    appType: "core",
+    versions: [],
   },
 ];
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,8 +33,8 @@ async redirects() {
 
 There have three content folders and their corresponding page, assets folder.
 
-- Docs folder has nested structure, by default it will accept all kinds of nested structure and compile the path into url. For example. A file in /docs/vdp/getting-started.mdx will be compiled into https://instill.tech/docs/vdp/getting-started.
-- Blog and tutorials currently only accept **flat** structure. This means it won't accept nested folder strcture likes /tutorial/nested-folder/foo.mdx.
+- Docs folder has nested structure, by default it will accept all kinds of nested structure and compile the path into url. For example. A file in /docs/v0.4.1-alpha/welcome.mdx will be compiled into https://instill.tech/docs/v0.4.1-alpha/welcome.
+- Blog and tutorials currently only accept **flat** structure. This means it won't accept nested folder structure likes /tutorial/nested-folder/foo.mdx.
 
 ```
 ├── blog
@@ -236,31 +236,24 @@ const SECTIONS: SidebarSections[] = [
   {
     //  <---- this menu will be added to cloud
     text: "Instill Cloud",
+    link: `/docs/${appVersion}/cloud`
     collapsible: true,
     items: [
-      {
-        text: "Getting started",
-        link: "/docs/cloud/getting-started",
+     {
+        text: "CLI",
+        link: `/docs/${appVersion}/core/deployment/cli`,
       },
       {
-        text: "Using Instill Cloud",
-        link: "/docs/cloud/using-instill-cloud",
+        text: "Docker Compose",
+        link: `/docs/${appVersion}/core/deployment/docker-compose`,
+      },
+      {
+        text: "Kubernetes",
+        link: `/docs/${appVersion}/core/deployment/kubernetes-using-helm`,
       },
     ],
-    appType: "cloud",
-  },
-  {
-    //  <---- this menu will be added to vdp
-    text: "VDP",
-    collapsible: true,
-    items: [
-      { text: "Getting started", link: "/docs/vdp/getting-started" },
-      { text: "Configuration", link: "/docs/vdp/configuration" },
-      { text: "Roadmap", link: "/docs/vdp/roadmap" },
-      { text: "License", link: "/docs/vdp/license" },
-      { text: "FAQ", link: "/docs/vdp/faq" },
-    ],
-    appType: "vdp",
+    appType: "core",
+    versions: [],
   },
 ];
 ```

--- a/blog/celebrate-Hacktoberfest-2023.mdx
+++ b/blog/celebrate-Hacktoberfest-2023.mdx
@@ -155,7 +155,7 @@ Instill AI must accept your pull/merge requests for them to count toward your to
 
 To get started, check out these helpful resources:
 
-- Instill AI [Documentation](https://www.instill.tech/docs/?utm_source=blog&utm_medium=link&utm_campaign=celebrate-hacktoberfest-2023): Get familiar with our product and explore its capabilities.
+- Instill AI [Documentation](/docs/?utm_source=blog&utm_medium=link&utm_campaign=celebrate-hacktoberfest-2023): Get familiar with our product and explore its capabilities.
 - Instill AI [GitHub Repository](https://github.com/instill-ai/community/issues?q=is:issue+is:open+label:hacktoberfest,+label:%22good+first+issue%22,%22help+wanted%22+): Discover existing issues and explore our ongoing projects.
 - Hacktoberfest [Submission Form](https://forms.gle/2r91a7ChMLVnWLm37): Once the work is completed, ensure that you submit the form to claim the credits. (Please submit multiple times for each task you complete)
 - Instill AI [Discord](https://discord.gg/sevxWsqpGh): If you have any questions or need further information regarding Hacktoberfest or Instill AI, please feel free to visit our Discord.

--- a/blog/introducing-vdp.mdx
+++ b/blog/introducing-vdp.mdx
@@ -34,7 +34,8 @@ VDP streamlines the end-to-end unstructured data processing pipeline:
 
 _We believe VDP is the future for unstructured data ETL, where developers won't need to build their own data connectors, high-maintenance model serving platform or ELT pipeline automation tool._
 
-Our mission is to make VDP the single point of unstructured data integration, so users can sync unstructured data from anywhere into centralised warehouses or applications and focus on gaining insights across all data sources, just like how the modern data stack handles structured data. Check out [highlights](/docs/latest/vdp/getting-started?utm_source=blog&utm_medium=link&utm_campaign=introducing-vdp) and [core concepts](/docs/latest/core/concepts?utm_source=blog&utm_medium=link&utm_campaign=introducing-vdp) if you want to learn more about how VDP works.
+Our mission is to make VDP the single point of unstructured data integration, so users can sync unstructured data from anywhere into centralised warehouses or applications and focus on gaining insights across all data sources, just like how the modern data stack handles structured data.
+Check out [highlights](/docs/latest/welcome?utm_source=blog&utm_medium=link&utm_campaign=introducing-vdp) and [core concepts](/docs/latest/core/concepts?utm_source=blog&utm_medium=link&utm_campaign=introducing-vdp) if you want to learn more about how VDP works.
 
 ~~To benefit a broader community, we release VDP under the open-source Apache license 2.0. Check it out [here](https://github.com/instill-ai/vdp/blob/main/LICENSE).~~
 
@@ -43,11 +44,11 @@ Our mission is to make VDP the single point of unstructured data integration, so
   and open-source MIT License as of May 2023. Our mission is to make AI
   accessible to everyone. The best way to achieve this is to make VDP free to
   use and source available to everyone, while ensuring we safely create a
-  sustainable business. Please check the [VDP License](/docs/latest/vdp/license) in
+  sustainable business. Please check the [VDP License](/docs/latest/license) in
   detail.
 </InfoBlock>
 
-We've made it easy to get started with VDP on your local machine and Kubernetes. Click here to [get started](/docs/latest/vdp/getting-started?utm_source=blog&utm_medium=link&utm_campaign=introducing-vdp).
+We've made it easy to get started with VDP on your local machine and Kubernetes. Click here to [get started](/docs/latest/quickstart?utm_source=blog&utm_medium=link&utm_campaign=introducing-vdp).
 If you want to chat about VDP or share your use cases, come and hang out with us in our [Discord community](http://go.instill.tech/4ey9lz).
 
 ## What is VDP not?
@@ -58,11 +59,11 @@ Many brilliant MLOps platforms/tools providing AI solutions have emerged in the 
 - Platforms that serve a specific vertical, such as E-commerce, and manufacturing.
 - Platforms that focus on a single component of MLOps, such as data labelling, dataset preparation, and model serving.
 
-VDP is built from a **data-driven** perspective. Although the AI model is the most critical component in an unstructured data ETL pipeline, the ultimate goal of VDP is to streamline the end-to-end unstructured data flow, with the transform component being able to flexibly import AI models from different sources. Please see the detailed [FAQ](/docs/latest/vdp/faq?utm_source=blog&utm_medium=link&utm_campaign=introducing-vdp) page.
+VDP is built from a **data-driven** perspective. Although the AI model is the most critical component in an unstructured data ETL pipeline, the ultimate goal of VDP is to streamline the end-to-end unstructured data flow, with the transform component being able to flexibly import AI models from different sources. Please see the detailed [FAQ](/docs/latest/faq?utm_source=blog&utm_medium=link&utm_campaign=introducing-vdp) page.
 
 ## Self-hosted and Cloud versions
 
-VDP is in Alpha and under active and heavy development. Check out our open [roadmap](/docs/latest/vdp/roadmap?utm_source=blog&utm_medium=link&utm_campaign=introducing-vdp). If you have any questions or feature requests, [create an issue](https://github.com/instill-ai/community/issues) or hop into our [Discord](http://go.instill.tech/4ey9lz) to get help from an active and friendly community!
+VDP is in Alpha and under active and heavy development. Check out our open [roadmap](/docs/latest/roadmap?utm_source=blog&utm_medium=link&utm_campaign=introducing-vdp). If you have any questions or feature requests, [create an issue](https://github.com/instill-ai/community/issues) or hop into our [Discord](http://go.instill.tech/4ey9lz) to get help from an active and friendly community!
 
 Our team is working hard to build out a fully-managed cloud product for VDP.
 

--- a/draft/vdp-101-3-create-your-first-pipeline.mdx
+++ b/draft/vdp-101-3-create-your-first-pipeline.mdx
@@ -48,7 +48,7 @@ VDP currently supports two sources, **HTTP** and **gRPC**. An HTTP source accept
 
 <InfoBlock type="info" title="info">
   Check our growing list of [Source
-  Connectors](/docs/latest/source-connectors/overview/?utm_source=blog&utm_medium=link&utm_campaign=vdp-101-3-create-your-first-pipeline).
+  Connectors](/docs/latest/vdp/operators/start/?utm_source=blog&utm_medium=link&utm_campaign=vdp-101-3-create-your-first-pipeline).
 </InfoBlock>
 
 To set up a **Source Connector**,
@@ -79,7 +79,7 @@ To set it up,
   alt="Import a model from a GitHub repository via VDP Console."
 />
 
-Check out the [documentation](/docs/latest/core-concepts/model/?utm_source=blog&utm_medium=link&utm_campaign=vdp-101-3-create-your-first-pipeline).
+Check out the [documentation](/docs/latest/model/import/github/?utm_source=blog&utm_medium=link&utm_campaign=vdp-101-3-create-your-first-pipeline).
 
 ## Step 4: Add an HTTP destination
 
@@ -124,8 +124,8 @@ The **green** light indicates the pipeline is `Active` and can be triggered via 
 It may take a while to see the status indicator turning green since deploying the model and activating the pipeline require time.
 
 <InfoBlock type="info" title="info">
-  Check out the [documentation](/docs/latest/core/pipeline) to
-  understand all the pipeline states.
+  Check out the [documentation](/docs/latest/core/pipeline) to understand all
+  the pipeline states.
 </InfoBlock>
 
 <img

--- a/draft/vdp-101-5-how-to-parse-vdp-responses.mdx
+++ b/draft/vdp-101-5-how-to-parse-vdp-responses.mdx
@@ -117,7 +117,7 @@ Taking object detection as an example, if you pass **N** images to the pipeline,
 ---
 
 `task` indicates the AI task the model designed to solve. Please read the following section about [what AI tasks are supported by VDP](#ai-tasks-supported-by-vdp).
-Note that when [importing a model](/docs/latest/import-models/overview/?utm_source=blog&utm_medium=link&utm_campaign=vdp-101-5-how-to-parse-vdp-responses), users need to [specify the corresponding AI task in the model card](/docs/latest/prepare-models/model-card/?utm_source=blog&utm_medium=link&utm_campaign=vdp-101-5-how-to-parse-vdp-responses).
+Note that when [importing a model](/docs/latest/model/import/?utm_source=blog&utm_medium=link&utm_campaign=vdp-101-5-how-to-parse-vdp-responses), users need to [specify the corresponding AI task in the model card](/docs/latest/model/prepare/?utm_source=blog&utm_medium=link&utm_campaign=vdp-101-5-how-to-parse-vdp-responses).
 
 ```shellscript focus=9:9
 

--- a/draft/vdp-101-6-pipeline-modes.mdx
+++ b/draft/vdp-101-6-pipeline-modes.mdx
@@ -52,7 +52,7 @@ A pipeline in the `ASYNC` mode performs an asynchronous workload. The user trigg
   alt="In ASYNC mode, VDP responses pipeline trigger requests with simple ACKs. Task outputs are loaded to destinations defined in the pipelines."
 />
 
-To create an `ASYNC` pipeline, the source can be either HTTP or gRPC, and the destination can be any [VDP destination connectors](/docs/latest/vdp/core-concepts/connector#destination).
+To create an `ASYNC` pipeline, the source can be either HTTP or gRPC, and the destination can be any [VDP data connectors](/docs/latest/vdp/data-connector).
 
 This mode is for use cases that do not require the inference results immediately.
 

--- a/src/components/hacktoberfest/Hero/Hero.tsx
+++ b/src/components/hacktoberfest/Hero/Hero.tsx
@@ -46,7 +46,7 @@ export const Hero = () => {
             className="border-semantic-bg-primar flex w-full items-center gap-x-2 xl:w-auto"
           >
             <a
-              href="https://www.instill.tech/docs/core/welcome/?utm_source=product&utm_medium=button"
+              href="https://www.instill.tech/docs/latest/core/deployment/?utm_source=product&utm_medium=button"
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/src/components/landing/CodeShowcase/CodeShowcase.tsx
+++ b/src/components/landing/CodeShowcase/CodeShowcase.tsx
@@ -73,7 +73,7 @@ export const CodeShowcase = ({ marginBottom }: CodeShowcaseProps) => {
         content: (
           <AccordionContent
             bgColor="bg-instillNatureGreen"
-            link="/docs/latest/core-concepts/vdp/connector#source"
+            link="/docs/latest/vdp/data-connector"
             description="A data connector in charge of ingesting 
               unstructured data into a Pipeline."
           />
@@ -89,7 +89,7 @@ export const CodeShowcase = ({ marginBottom }: CodeShowcaseProps) => {
         content: (
           <AccordionContent
             bgColor="bg-instillLemonYellow50"
-            link="docs/core-concepts/model"
+            link="docs/latest/model/ai-task"
             description="An algorithm that runs on unstructured 
               data to solve a certain AI task."
           />
@@ -105,7 +105,7 @@ export const CodeShowcase = ({ marginBottom }: CodeShowcaseProps) => {
         content: (
           <AccordionContent
             bgColor="bg-instillWarmOrange50"
-            link="/docs/latest/core-concepts/vdp/connector#destination"
+            link="/docs/latest/vdp/data-connector"
             description="A data connector to load the standarised 
               AI task output from model to the destination."
           />
@@ -136,7 +136,7 @@ export const CodeShowcase = ({ marginBottom }: CodeShowcaseProps) => {
         </p>
         <CommonCtaButton
           text="See documentation"
-          link="/docs/latest/vdp/welcome"
+          link="/docs/latest/welcome"
           withArrow={true}
           position="mr-auto"
         />

--- a/src/components/landing/Faq/Faq.tsx
+++ b/src/components/landing/Faq/Faq.tsx
@@ -51,7 +51,7 @@ export const Faq = ({ marginBottom }: FaqProps) => {
                   <FaqContent>
                     {`VDP uses multiple licenses, including Elastic License 2.0 (ELv2) and open-source MIT License.
                   Our mission is to make AI accessible to everyone. The best way to achieve this is to make VDP free to use and source available to everyone, while ensuring we safely create a sustainable business.
-                  Please check the [VDP License](../docs/vdp/license) in detail.`}
+                  Please check the [VDP License](../docs/latest/license) in detail.`}
                   </FaqContent>
                 ),
               },
@@ -120,7 +120,7 @@ We are adding new features every day and we need your feedback to help shape the
             withArrow={true}
             position="xl:ml-auto"
             text="See all FAQ"
-            link="/docs/latest/vdp/faq"
+            link="/docs/latest/faq"
           />
         </div>
       </div>

--- a/src/components/landing/Hero/GitHubCtaButton.tsx
+++ b/src/components/landing/Hero/GitHubCtaButton.tsx
@@ -24,9 +24,7 @@ export const GitHubCtaButton = ({ position }: GitHubCtaButtonProps) => {
       padding="pl-[15px] pr-[56px] py-[7px]"
       position={position}
       onClickHandler={() =>
-        router.push(
-          "/docs/latest/vdp/welcome/?utm_source=product&utm_medium=button"
-        )
+        router.push("/docs/?utm_source=product&utm_medium=button")
       }
     >
       <div className="flex flex-col">

--- a/src/components/landing/HowItWorks/HowItWorks.tsx
+++ b/src/components/landing/HowItWorks/HowItWorks.tsx
@@ -44,7 +44,7 @@ export const HowItWorks = forwardRef<HTMLDivElement, HowItWorksProps>(
             type="left"
             title="Pre-built ETL data connectors for extensive data access"
             description="By leveraging ready-to-use data connectors, VDP is the single point of unstructured data integration, where you can sync unstructured data from anywhere into data warehouses or applications. Focus on gaining insights across all your data, instead of maintaining connectors."
-            learnMoreLink="/docs/latest/core-concepts/vdp/connector"
+            learnMoreLink="/docs/latest/vdp/data-connector"
             number={1}
             cubes={[
               {
@@ -81,7 +81,7 @@ export const HowItWorks = forwardRef<HTMLDivElement, HowItWorksProps>(
             type="right"
             title="One-click import and deploy AI models across vendors and frameworks"
             description="VDP integrates with the best ML tools and platforms to make importing models super easy. Get access to state-of-the-art models across vendors and your own models without changing your workflow. It supports frameworks including TensorRT, PyTorch, TensorFlow, ONNX, Python and more."
-            learnMoreLink="/docs/latest/import-models/overview"
+            learnMoreLink="/docs/latest/model/import"
             number={2}
             cubes={[
               {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -237,7 +237,7 @@ const HacktoberfestPage: FC & {
                   className="w-full items-center gap-x-2 border-semantic-bg-primary xl:w-auto"
                 >
                   <a
-                    href="https://www.instill.tech/docs/core/welcome?utm_source=product&utm_medium=button"
+                    href="https://www.instill.tech/docs/?utm_source=product&utm_medium=button"
                     target="_blank"
                     rel="noopener noreferrer"
                   >

--- a/src/pages/pricing.tsx
+++ b/src/pages/pricing.tsx
@@ -50,7 +50,7 @@ const pricingPlans: PricingPlan[] = [
     name: "Cloud Starter",
     price: "Free",
     subTitle: null,
-    subTitleLink: "/docs/latest/cloud/getting-started",
+    subTitleLink: "/docs/latest/quickstart",
     description: "For individual or small teams with advanced features",
     features: [
       "FREE compute resource during Open Alpha",

--- a/tutorials/vdp-aigc-web3-stability-ai-numbers-protocol.mdx
+++ b/tutorials/vdp-aigc-web3-stability-ai-numbers-protocol.mdx
@@ -47,12 +47,12 @@ Let's dive into the tutorial and start building this powerful AIGC x Web3 pipeli
 ## Preparation
 
 You have two options to access Instill VDP: via the cloud platform Instill Cloud or by self-hosting Instill Core.
-For more information on each option, please refer to the documentation [here](https://www.instill.tech/docs/cloud/welcome/?utm_source=tutorial&utm_medium=link&utm_campaign=vdp-aigc-web3-stability-ai-numbers-protocol).
+For more information on each option, please refer to the documentation [here](/docs/?utm_source=tutorial&utm_medium=link&utm_campaign=vdp-aigc-web3-stability-ai-numbers-protocol).
 
 ### Access Instill VDP via Instill Cloud (Recommended)
 
 [Instill Cloud](https://console.instill.tech/?utm_source=tutorial&utm_medium=link&utm_campaign=vdp-aigc-web3-stability-ai-numbers-protocol) is the recommended method for accessing Instill VDP, offering ease of use and reliability.
-To get started, all you need is an Instill Cloud account. Follow these steps to [set up your Instill Cloud account and log in to the Instill Cloud Console](https://www.instill.tech/docs/cloud/getting-started/?utm_source=tutorial&utm_medium=link&utm_campaign=vdp-aigc-web3-stability-ai-numbers-protocol).
+To get started, all you need is an Instill Cloud account. Follow these steps to [set up your Instill Cloud account and log in to the Instill Cloud Console](/docs/latest/quickstart/?utm_source=tutorial&utm_medium=link&utm_campaign=vdp-aigc-web3-stability-ai-numbers-protocol).
 
 ### Run Instill VDP via Instill Core locally
 
@@ -93,7 +93,7 @@ After onboarding, you will be redirected to the **Pipeline** page. If you have
 
 ### Step 1/4: Create Resource for each connector
 
-For make the pipeline workable, we need to first fill in your **API Key** for each connector. 
+For make the pipeline workable, we need to first fill in your **API Key** for each connector.
 
 For this example, we have Stability AI connector and Numbers Protocol connector. For Stability AI, follow the Stability AI **[documentation](https://platform.stability.ai/docs/getting-started/authentication)** to find your API keycreate resource. For Numbers Protocol, check out their [documentation](https://dia-backend.numbersprotocol.io/api/v3/redoc/) for capture token resource.
 
@@ -129,7 +129,7 @@ In this example,
 
 <ZoomableImg
   src="/tutorial-assets/vdp-aigc-web3-stability-ai-numbers-protocol/step2-set-stability-ai.png"
-    alt="Set up Stability AI connector"
+  alt="Set up Stability AI connector"
 />
 
 ### Step 3/4: Set up a Numbers Protocol Blockchain Connector
@@ -143,8 +143,8 @@ In this example,
 2. Enter the referenced image you would like to turn into Web3 asset.
 
 3. Fill in all other fields as desired.
-    
-    Note: The license used for this asset is **`CC BY-SA`**, which is a highly permissive license. For more information about this license, you can check **[here](https://creativecommons.org/licenses/by-sa/4.0/)**.
+
+   Note: The license used for this asset is **`CC BY-SA`**, which is a highly permissive license. For more information about this license, you can check **[here](https://creativecommons.org/licenses/by-sa/4.0/)**.
 
 4. Click **save** at the bottom-right of the right side bar to save the settings.
 
@@ -159,7 +159,7 @@ This connector ensures your data file will be pinned on the IPFS network with on
 
 Almost there! All connectors will be automatically linked if successfully referencing connecters and operators. Then your pipeline will be ready to go!
 
-Now, 
+Now,
 
 1. Click **Save 💾** on the top-right corner of the console to save the pipeline.
 
@@ -171,9 +171,9 @@ Now,
 />
 
 3. Enter empty fields in Start Operator.
-    
-    Note: Don't forget to personalize the **`asset_creator`** field by using your own name to claim ownership of the generated asset. 
-    
+
+   Note: Don't forget to personalize the **`asset_creator`** field by using your own name to claim ownership of the generated asset.
+
 4. Click **Run** to trigger the pipeline.
 
 <ZoomableImg
@@ -181,7 +181,7 @@ Now,
   alt="Trigger the pipeline by clicking Run"
 />
 
-5. The result for AI generated Art and Web3 Asset URLs will be shown at the End Operator. 
+5. The result for AI generated Art and Web3 Asset URLs will be shown at the End Operator.
 
 <ZoomableImg
   src="/tutorial-assets/vdp-aigc-web3-stability-ai-numbers-protocol/step4-result.png"
@@ -219,9 +219,9 @@ To create an API token, follow these steps:
 
 1. Go to the **[homepage](https://console.instill.tech/)** of the console.
 1. Click **Settings** ⚙️ on the bottom-left
-2. Navigate to the **API Tokens** page
-3. Just give it an ID and click **Create Token**
-4. The API token will be generated and displayed in the table. Keep this token safe as it does not expire.
+1. Navigate to the **API Tokens** page
+1. Just give it an ID and click **Create Token**
+1. The API token will be generated and displayed in the table. Keep this token safe as it does not expire.
 
 <InfoBlock type="tip" title="tip">
   If your token is compromised, choose that token and click Delete. But be
@@ -232,7 +232,6 @@ To create an API token, follow these steps:
 ### Trigger the pipeline
 
 To trigger the pipeline, you can use cURL with the provided API token as a Bearer token in the authorization headers (required only for Instill Cloud). Here's an example of how to do it:
-
 
 ```shellscript Trigger-via-Instill-Cloud
 curl -X POST 'https://api.instill.tech/vdp/v1alpha/users/shihchun-h/pipelines/aigc-web3/trigger' \
@@ -250,7 +249,6 @@ curl -X POST 'https://api.instill.tech/vdp/v1alpha/users/shihchun-h/pipelines/ai
 }'
 ```
 
-
 ```shellscript Trigger-via-Instill-Core
 curl -X POST 'http://localhost:8080/v1alpha/pipelines/aigc-web3/trigger' \
 --data  '{
@@ -265,12 +263,11 @@ curl -X POST 'http://localhost:8080/v1alpha/pipelines/aigc-web3/trigger' \
 }'
 ```
 
-
 <InfoBlock type="info" title="info">
   To understand the Numbers Protocol related parameters in the `metadata` field,
   including details about the asset creator and license, you can refer to the
-  [documentation](https://www.instill.tech/docs/vdp/v1.0.0/blockchain-connectors/numbers-protocol)
-  for comprehensive information.
+  [documentation](/docs/latest/vdp/connectors/numbers-protocol) for
+  comprehensive information.
 </InfoBlock>
 
 Please be patient as the request may take a a dozen seconds to process. Once completed, you will receive a response.

--- a/tutorials/vdp-streamlit-yolov7.mdx
+++ b/tutorials/vdp-streamlit-yolov7.mdx
@@ -81,7 +81,7 @@ A pipeline in `SYNC` mode responds to a request synchronously. It is suitable fo
 <InfoBlock type="info" title="info">
   No matter where your model stores, we want to keep your models in the same
   place without changes. VDP [integrates with many model platforms and
-  tools](/docs/latest/import-models/overview?utm_source=tutorial&utm_medium=link&utm_campaign=vdp-streamlit-yolov7)
+  tools](/docs/latest/model/import?utm_source=tutorial&utm_medium=link&utm_campaign=vdp-streamlit-yolov7)
   to make importing models as easy as possible.
 </InfoBlock>
 


### PR DESCRIPTION
Because

- we want to keep the outdated links up-to-date

This commit

- fix outdated links in product website, tutorials and blogs
