### PR TITLE
fix: change version v0.8.0-alpha to v0.8.0-beta

### DIFF
--- a/content.config.tsx
+++ b/content.config.tsx
@@ -568,10 +568,10 @@ export function getNavbar(
         items: [
           {
             key: "docs-nav-dropdown-version-core-latest",
-            to: `/docs/v0.8.0-alpha/welcome`,
+            to: `/docs/v0.8.0-beta/welcome`,
             className: "",
             position: "right",
-            label: "v0.8.0-alpha (latest)",
+            label: "v0.8.0-beta (latest)",
             appType: "core",
           },
           {

--- a/version.mjs
+++ b/version.mjs
@@ -1,3 +1,3 @@
 export const LATEST_VERSIONS = {
-  core: "v0.8.0-alpha",
+  core: "v0.8.0-beta",
 };


### PR DESCRIPTION
Because

- the original document version was wrong

This commit

- change version `v0.8.0-alpha` to `v0.8.0-beta`
