### PR TITLE
fix: remove button inside button

### DIFF
--- a/src/components/landing/jumbotron/Jumbotron.tsx
+++ b/src/components/landing/jumbotron/Jumbotron.tsx
@@ -75,13 +75,7 @@ export const Jumbotron = () => {
         <SwiperButtonPrev
           onClickHandler={() => setCurrentSlide(currentSlide - 1)}
         >
-          <Button
-            variant="secondaryGrey"
-            size="lg"
-            className="absolute top-96 z-10 hidden rounded-[50px] !p-3 xl:left-7 xl:block"
-          >
-            <Icons.ChevronLeft className="h-6 w-6 stroke-slate-500" />
-          </Button>
+          <Icons.ChevronLeft className="h-6 w-6 stroke-slate-500" />
         </SwiperButtonPrev>
         <SwiperSlide className="shadow-lg">
           <StabilityAIOpenAISticker />
@@ -98,13 +92,7 @@ export const Jumbotron = () => {
         <SwiperButtonNext
           onClickHandler={() => setCurrentSlide(currentSlide + 1)}
         >
-          <Button
-            variant="secondaryGrey"
-            size="lg"
-            className="absolute top-96 z-10 hidden rounded-[50px] !p-3 xl:right-7 xl:block"
-          >
-            <Icons.ChevronRight className="h-6 w-6 stroke-slate-500" />
-          </Button>
+          <Icons.ChevronRight className="h-6 w-6 stroke-slate-500" />
         </SwiperButtonNext>
       </Swiper>
     </div>

--- a/src/components/landing/jumbotron/SwiperButtonNext.tsx
+++ b/src/components/landing/jumbotron/SwiperButtonNext.tsx
@@ -1,5 +1,6 @@
 import { useSwiper } from "swiper/react";
 import { SwiperButtonProps } from "./SwiperButtonPrev";
+import { Button } from "@instill-ai/design-system";
 
 export const SwiperButtonNext = ({
   children,
@@ -8,14 +9,17 @@ export const SwiperButtonNext = ({
   const swiper = useSwiper();
 
   return (
-    <button
+    <Button
       id="nextButton"
       onClick={() => {
         swiper.slideNext();
         onClickHandler();
       }}
+      variant="secondaryGrey"
+      size="lg"
+      className="absolute top-96 z-10 hidden rounded-[50px] !p-3 xl:right-7 xl:block"
     >
       {children}
-    </button>
+    </Button>
   );
 };

--- a/src/components/landing/jumbotron/SwiperButtonPrev.tsx
+++ b/src/components/landing/jumbotron/SwiperButtonPrev.tsx
@@ -1,5 +1,6 @@
 import { ReactElement } from "react";
 import { useSwiper } from "swiper/react";
+import { Button } from "@instill-ai/design-system";
 
 export type SwiperButtonProps = {
   children: ReactElement | string;
@@ -13,14 +14,17 @@ export const SwiperButtonPrev = ({
   const swiper = useSwiper();
 
   return (
-    <button
+    <Button
       id="prevButton"
       onClick={() => {
         swiper.slidePrev();
         onClickHandler();
       }}
+      variant="secondaryGrey"
+      size="lg"
+      className="absolute top-96 z-10 hidden rounded-[50px] !p-3 xl:left-7 xl:block"
     >
       {children}
-    </button>
+    </Button>
   );
 };


### PR DESCRIPTION
Because

- a button can't be a children of a button, nextjs was breaking with this error and I couldnt work on another issue

<img width="800" alt="image" src="https://github.com/instill-ai/instill.tech/assets/16295402/1d92ad4c-e342-4c65-a5a4-15f4f778bf9b">



This commit

- just replaces a button inside another button with just one button

all is working as it was before

<img width="800" alt="image" src="https://github.com/instill-ai/instill.tech/assets/16295402/cf839d28-d0d4-4cfc-9b85-9f02b7ac8769">

