### PR TITLE
feat: while switching between dark/light add splash effect

### DIFF
--- a/src/hooks/useDarkTheme.tsx
+++ b/src/hooks/useDarkTheme.tsx
@@ -14,11 +14,15 @@ const useDarkTheme = () => {
   }, [setIsDark]);
 
   useEffect(() => {
+    let timeout: NodeJS.Timeout;
     const html = document.querySelector("html");
     if (!html) return;
     if (setIsDark) {
       //  Add or Remove "dark" classname
       setIsDark((prevIsDark) => {
+        // Add dark mode transition
+        html.classList.add("dark-transition");
+
         if (prevIsDark) {
           html.classList.add("dark");
           //  Set value on localstorage true
@@ -28,9 +32,19 @@ const useDarkTheme = () => {
           //  Set value on localstorage false
           localStorage.setItem("dark", "false");
         }
+        timeout = setTimeout(() => {
+          // Remove dark mode transition
+          html.classList.remove("dark-transition");
+          clearTimeout(timeout);
+        }, 500);
         return prevIsDark;
       });
     }
+    return () => {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+    };
   }, [isDark, setIsDark]);
 
   return [isDark, setIsDark] as const;

--- a/src/pages/docs/[...path].tsx
+++ b/src/pages/docs/[...path].tsx
@@ -195,7 +195,7 @@ const DocsPage: FC<DocsPageProps> & {
           </h1>
           <article
             id="content"
-            className="DocSearch-content prose mb-20 max-w-none dark:prose-white dark:bg-instillGrey90"
+            className="DocSearch-content prose mb-20 max-w-none dark:prose-white"
           >
             {mdxSource ? <MDXRemote {...mdxSource} /> : null}
           </article>

--- a/src/styles/docs.css
+++ b/src/styles/docs.css
@@ -9,6 +9,10 @@
   --docs-content-max-width: 1140px;
 }
 
+html.dark-transition * {
+  @apply transition-colors duration-200;
+}
+
 /*
   DocSearch styles
 */


### PR DESCRIPTION
Because

- while switching to dark/light mode need to add some css effects

This commit

- adds a quick implementation using tailwind + javascript


https://github.com/instill-ai/instill.tech/assets/16295402/c3bafeae-bed0-4925-9242-21c833cf89ad


