### PR TITLE
chore: update jumbotron-visual-understanding card on website since the Model task has been changed

### DIFF
--- a/src/components/landing/jumbotron/Llama2Chat.tsx
+++ b/src/components/landing/jumbotron/Llama2Chat.tsx
@@ -151,7 +151,7 @@ export const Llama2Chat = () => {
     const apiResponse = await JumbotronSDK.llava7b({
       inputs: [
         {
-          image: imagePreview ? imagePreview : defaultImage || "",
+          images: [imagePreview ? imagePreview : defaultImage || ""],
           prompt: question,
         },
       ],

--- a/src/lib/jumbotron-sdk/llava7b.ts
+++ b/src/lib/jumbotron-sdk/llava7b.ts
@@ -5,7 +5,7 @@ import { handleInstillError } from "./utility";
 
 export type Llaba7bRequestData = {
   inputs: {
-    image: string;
+    images: string[];
     prompt: string;
   }[];
 };
@@ -14,7 +14,7 @@ export async function llava7b(
   requestData: Llaba7bRequestData
 ): Promise<JumbotronRequestResponse> {
   const body: InstillAPIProxyRequestBody = {
-    path: "/vdp/v1beta/users/instill-wombat/pipelines/jumbotron-visual-understanding/releases/v1.0.0/trigger",
+    path: "/vdp/v1beta/users/instill-wombat/pipelines/jumbotron-visual-understanding/releases/v2.0.0/trigger",
     data: requestData,
   };
 


### PR DESCRIPTION
Because

- update jumbotron-visual-understanding card on website since the Model task has been changed

This commit

- update jumbotron-visual-understanding card on website since the Model task has been changed
