### PR TITLE
docs(blog): add no-code section in GA

### DIFF
--- a/blog/vdp-open-beta.mdx
+++ b/blog/vdp-open-beta.mdx
@@ -193,14 +193,16 @@ We firmly believe that no-code truly shines when combined with full visibility a
 
 ### Better comprehensive communication among different teams
 
-Through our year-long exploration and user interviews, we identified a significant gap between the creators and users of AI tools within the company. This gap manifests in two key challenges.
-Firstly, consumers often find it challenging to customize the tools to suit their specific needs, such as incorporating additional parameters into the triggering process.
+Through our year-long exploration and user interviews, we have identified a significant gap between the creators and users of AI tools within the company.
+This gap manifests in two key challenges.
+Firstly, consumers often struggle to customize the tools to meet their specific needs, such as incorporating additional parameters into the triggering process.
 Secondly, communication hurdles arise due to the complexity of conveying how a tool was built; inadequate documentation exacerbates this issue, hindering the user’s understanding.
 The root cause of this gap appears to be a lack of a common language. While builders utilize a “Programming Language” to construct the tool, consumers rely on “Natural Language” for comprehension.
-We firmly believe that the VDP serves as a potent solution to address this problem. Looking ahead. 
-We aim to introduce a more sophisticated documentation editor, allowing direct references to the components used in the pipeline.
+We firmly believe that the Instill VDP serves as a potent solution to address this problem.
+
+Moving forward, we aim to introduce a more sophisticated documentation editor, allowing direct references to the components used in the pipeline.
 Users can easily navigate to specific components by clicking on them within the documentation.
-Additionally, we are working to fortify the communication layer of the pipeline, enabling real-time collaboration and interaction.
+Additionally, we are working to strengthen the communication layer of the pipeline, enabling real-time collaboration and interaction.
 These advancements will contribute to a more seamless and comprehensible experience for both builders and consumers in our AI ecosystem.
 
 ### Focusing on performance optimization

--- a/blog/vdp-open-beta.mdx
+++ b/blog/vdp-open-beta.mdx
@@ -220,9 +220,9 @@ These enhancements are targeted to elevate the performance and usability of Inst
 
 Instill VDP forms a key component of our turn-key solution designed to address unstructured data ETL challenges, catering to both Bring Your Own Cloud (BYOC) and on-premises deployment scenarios.
 
-- [**💧Instill VDP (Beta)**](https://github.com/instill-ai/vdp) - no-code/low-code pipeline builder that allows you to build, test, release and share custom AI pipelines for processing unstructured data.
-- [**⚗️Instill Model (Alpha)**](https://github.com/instill-ai/model) - A ModelOps platform facilitating the seamless import, training, and serving of AI models at scale. It streamlines AI model lifecycle management, enhancing efficiency and scalability for developers.
-- **Instill Artifact (Coming soon)** - A data management platform designed to integrate effortlessly with Instill VDP and Instill Model. It ensures data is readily accessible and in the right format for AI model training and pipeline execution.
+- 💧 [**Instill VDP (Beta)**](https://github.com/instill-ai/vdp) - no-code/low-code pipeline builder that allows you to build, test, release and share custom AI pipelines for processing unstructured data.
+- ⚗️ [**Instill Model (Alpha)**](https://github.com/instill-ai/model) - A ModelOps platform facilitating the seamless import, training, and serving of AI models at scale. It streamlines AI model lifecycle management, enhancing efficiency and scalability for developers.
+- 💾 **Instill Artifact (Coming soon)** - A data management platform designed to integrate effortlessly with Instill VDP and Instill Model. It ensures data is readily accessible and in the right format for AI model training and pipeline execution.
 
 <ZoomableImg
   src="/blog-assets/vdp-open-beta/triad-instill-core.png"

--- a/blog/vdp-open-beta.mdx
+++ b/blog/vdp-open-beta.mdx
@@ -191,6 +191,18 @@ This means you can visualize the logic and the entire data flow within your pipe
 It also makes debugging easier by pinpointing the source of errors, and it further allows you to effortlessly collect valuable data for training and analysis.
 We firmly believe that no-code truly shines when combined with full visibility and an intuitive user experience.
 
+### Better comprehensive communication among different teams
+
+Through our year-long exploration and user interviews, we identified a significant gap between the creators and users of AI tools within the company. This gap manifests in two key challenges.
+Firstly, consumers often find it challenging to customize the tools to suit their specific needs, such as incorporating additional parameters into the triggering process.
+Secondly, communication hurdles arise due to the complexity of conveying how a tool was built; inadequate documentation exacerbates this issue, hindering the user’s understanding.
+The root cause of this gap appears to be a lack of a common language. While builders utilize a “Programming Language” to construct the tool, consumers rely on “Natural Language” for comprehension.
+We firmly believe that the VDP serves as a potent solution to address this problem. Looking ahead. 
+We aim to introduce a more sophisticated documentation editor, allowing direct references to the components used in the pipeline.
+Users can easily navigate to specific components by clicking on them within the documentation.
+Additionally, we are working to fortify the communication layer of the pipeline, enabling real-time collaboration and interaction.
+These advancements will contribute to a more seamless and comprehensible experience for both builders and consumers in our AI ecosystem.
+
 ### Focusing on performance optimization
 
 To optimize performance in Instill VDP, we're focusing on several crucial improvements:


### PR DESCRIPTION
Because

- we want to add how we want to improve the no-code documentation feature for GA

This commit

- add new section
