### PR TITLE
docs: update reference syntax in v0.10.0-beta document

### DIFF
--- a/docs/v0.10.0-beta/core/concepts/pipeline.en.mdx
+++ b/docs/v0.10.0-beta/core/concepts/pipeline.en.mdx
@@ -76,10 +76,10 @@ Let's begin with an example of a **configuration**:
   "input": {
     "field_1_primitive_value": "this is a book",
     "field_2_primitive_value": 1.0,
-    "field_3_reference": "{ start.a_string_field }",
-    "field_4_reference": "{ componentA.output.a_string_field }",
-    "field_5_reference": "{ componentA.output.a_number_array }",
-    "field_6_template": "{{ componentA.output.a_string_field }} and we have {{ componentB.output.a_number_field }}"
+    "field_3_reference": "${ start.a_string_field }",
+    "field_4_reference": "${ componentA.output.a_string_field }",
+    "field_5_reference": "${ componentA.output.a_number_array }",
+    "field_6_template": "${ componentA.output.a_string_field } and we have ${ componentB.output.a_number_field }"
   }
 }
 ```
@@ -125,7 +125,7 @@ When utilizing batch triggering in VDP, where each component processes an array 
 
 ### Reference
 
-- A Reference employs special syntax enclosed in single curly brackets, e.g., `{ start.a_string_field }`.
+- A Reference employs special syntax enclosed in single curly brackets, e.g., `${ start.a_string_field }`.
 - It functions as a variable reference, copying the value from an upstream component to the data input while preserving the original data type.
 
 **Example:**
@@ -136,9 +136,9 @@ Suppose we have the following component configuration:
 // Component configuration
 {
   "input": {
-    "field_3_reference": "{ start.a_string_field }",
-    "field_4_reference": "{ componentA.output.a_string_field }",
-    "field_5_reference": "{ componentA.output.a_number_array }"
+    "field_3_reference": "${ start.a_string_field }",
+    "field_4_reference": "${ componentA.output.a_string_field }",
+    "field_5_reference": "${ componentA.output.a_number_array }"
   }
 }
 ```
@@ -165,7 +165,7 @@ Given the provided upstream component data, the rendered data input for this com
 
 ### Template
 
-- A **Template** is a string comprising one or more **String Literals**, enclosed in double curly brackets, e.g., `{{ componentA.output.a_string_field }}`.
+- A **Template** is a string comprising one or more **String Literals**, enclosed in double curly brackets, e.g., `${ componentA.output.a_string_field }`.
 - It retrieves values from upstream components and converts them to string type for the data input.
 
 **Example:**
@@ -176,7 +176,7 @@ Consider the following component configuration:
 // Component configuration
 {
   "input": {
-    "field_6_template": "{{ componentA.output.a_string_field }} and we have {{ componentB.output.a_number_field }}"
+    "field_6_template": "${ componentA.output.a_string_field } and we have ${ componentB.output.a_number_field }"
   }
 }
 ```

--- a/docs/v0.10.0-beta/core/concepts/pipeline.zh_CN.mdx
+++ b/docs/v0.10.0-beta/core/concepts/pipeline.zh_CN.mdx
@@ -76,10 +76,10 @@ Let's begin with an example of a **configuration**:
   "input": {
     "field_1_primitive_value": "this is a book",
     "field_2_primitive_value": 1.0,
-    "field_3_reference": "{ start.a_string_field }",
-    "field_4_reference": "{ componentA.output.a_string_field }",
-    "field_5_reference": "{ componentA.output.a_number_array }",
-    "field_6_template": "{{ componentA.output.a_string_field }} and we have {{ componentB.output.a_number_field }}"
+    "field_3_reference": "${ start.a_string_field }",
+    "field_4_reference": "${ componentA.output.a_string_field }",
+    "field_5_reference": "${ componentA.output.a_number_array }",
+    "field_6_template": "${ componentA.output.a_string_field } and we have ${ componentB.output.a_number_field }"
   }
 }
 ```
@@ -125,7 +125,7 @@ When utilizing batch triggering in VDP, where each component processes an array 
 
 ### Reference
 
-- A Reference employs special syntax enclosed in single curly brackets, e.g., `{ start.a_string_field }`.
+- A Reference employs special syntax enclosed in single curly brackets, e.g., `${ start.a_string_field }`.
 - It functions as a variable reference, copying the value from an upstream component to the data input while preserving the original data type.
 
 **Example:**
@@ -136,9 +136,9 @@ Suppose we have the following component configuration:
 // Component configuration
 {
   "input": {
-    "field_3_reference": "{ start.a_string_field }",
-    "field_4_reference": "{ componentA.output.a_string_field }",
-    "field_5_reference": "{ componentA.output.a_number_array }"
+    "field_3_reference": "${ start.a_string_field }",
+    "field_4_reference": "${ componentA.output.a_string_field }",
+    "field_5_reference": "${ componentA.output.a_number_array }"
   }
 }
 ```
@@ -165,7 +165,7 @@ Given the provided upstream component data, the rendered data input for this com
 
 ### Template
 
-- A **Template** is a string comprising one or more **String Literals**, enclosed in double curly brackets, e.g., `{{ componentA.output.a_string_field }}`.
+- A **Template** is a string comprising one or more **String Literals**, enclosed in double curly brackets, e.g., `${ componentA.output.a_string_field }`.
 - It retrieves values from upstream components and converts them to string type for the data input.
 
 **Example:**
@@ -176,7 +176,7 @@ Consider the following component configuration:
 // Component configuration
 {
   "input": {
-    "field_6_template": "{{ componentA.output.a_string_field }} and we have {{ componentB.output.a_number_field }}"
+    "field_6_template": "${ componentA.output.a_string_field } and we have ${ componentB.output.a_number_field }"
   }
 }
 ```

--- a/docs/v0.10.0-beta/quickstart.en.mdx
+++ b/docs/v0.10.0-beta/quickstart.en.mdx
@@ -111,14 +111,14 @@ To configure an OpenAI connector:
 4. In the **Prompt** field, specify the text prompt to generate an LLM augmented prompt:
 
 ```
-Augment the prompt with descriptive details for generating sticker images, and add the styles exactly at the end of the prompt "sticker style, flat icon, vector, die-cut {{start.sticker_shape}} sticker with white border".
+Augment the prompt with descriptive details for generating sticker images, and add the styles exactly at the end of the prompt "sticker style, flat icon, vector, die-cut ${start.sticker_shape} sticker with white border".
 Only return the output content.
 
 Prompt: a bear
-Output: a brown bear dancing in a forest, sticker style, flat icon, vector, die-cut {{start.sticker_shape}} sticker with white border
+Output: a brown bear dancing in a forest, sticker style, flat icon, vector, die-cut ${start.sticker_shape} sticker with white border
 Prompt: a dog writes code
-Output: a dog writes code in front of a laptop and drinks coffee, sticker style, flat icon, vector, die-cut {{start.sticker_shape}} sticker with white border
-Prompt: {{start.prompt}}
+Output: a dog writes code in front of a laptop and drinks coffee, sticker style, flat icon, vector, die-cut ${start.sticker_shape} sticker with white border
+Prompt: ${start.prompt}
 Output:
 ```
 
@@ -133,14 +133,14 @@ You are a prompt engineer to generate Stable Diffusion prompts to generate stick
 8. Set **n** to in the _1_ to indicate only one chat completion.
 
 The OpenAI connector will automatically link to the Start operator
-since we have used `{{start.sticker_shape}}` and `{{start.prompt}}` in the OpenAI connector configuration.
-The `{{}}` placeholders represent **string values** to be filled during pipeline triggering.
+since we have used `${start.sticker_shape}` and `${start.prompt}` in the OpenAI connector configuration.
+The `${}` placeholders represent **string values** to be filled during pipeline triggering.
 
 To set up an Stability AI connector:
 
 1. Click **+ Add Component** and choose **stability-ai** from existing resource. This will add a OpenAI connector `stability_0` to the canvas.
 2. Select _TASK_TEXT_TO_IMAGE_ from the dropdown of the **Stability AI Component** field.
-3. In the **Prompts** field, specify the generated text array from the OpenAI connector output `{openai_0.output.texts}`.
+3. In the **Prompts** field, specify the generated text array from the OpenAI connector output `${openai_0.output.texts}`.
 4. Click the **Advanced configuration** link on the `stability_0` component to open configuration right panel.
 5. Choose the **Engine** to use, e.g., _stable-diffusion-xl-1024-v1-0_.
 6. Adjust **CFG Scale** to control how strictly the diffusion process adheres to the text prompt, e.g., set it to _8_.
@@ -149,11 +149,11 @@ To set up an Stability AI connector:
 9. Fill **Steps** to _30_ to indicate the number of diffusion steps to run.
 
 You will see that the Stability AI connector is automatically linked to the OpenAI connector
-since we have used `{openai_0.output.texts}` in the Stability AI connector configuration.
+since we have used `${openai_0.output.texts}` in the Stability AI connector configuration.
 
 <InfoBlock type="tip" title="Tip">
-  The `{}` placeholders are used to reference values from previous connectors.
-  Unlike the `{{}}` placeholders, `{}` retains the type of the referenced value.
+  The `${}` placeholders are used to reference values from previous connectors.
+  Unlike the `${}` placeholders, `${}` retains the type of the referenced value.
 </InfoBlock>
 
 The End Operator is used at the end of a VDP pipeline to receive the output as a response when triggering the pipeline.
@@ -161,10 +161,10 @@ The End Operator is used at the end of a VDP pipeline to receive the output as a
 To set up an End operator:
 
 1. Find the **end** operator on canvas.
-2. Click **Add Field +** and fill in the **Title** with _My Original Prompt_, **Key** with _my_original_prompt_ and **Value** with `{start.prompt}`. Click **Save**.
-3. Click **Add Field +** and fill in the **Title** with _Sticker Shape_, **Key** with _sticker_shape_ and **Value** with `{start.sticker_shape}`. Click **Save**.
-4. Click **Add Field +** and fill in the **Title** with _LLM Powered Prompt_, **Key** with _llm_powered_prompt_ and **Value** with `{openai_0.output.texts}`. Click **Save**.
-5. Click **Add Field +** and fill in the **Title** with _Digital Sticker_, **Key** with _digital_sticker_ and **Value** with `{stability_0.output.images}`. Click **Save**.
+2. Click **Add Field +** and fill in the **Title** with _My Original Prompt_, **Key** with _my_original_prompt_ and **Value** with `${start.prompt}`. Click **Save**.
+3. Click **Add Field +** and fill in the **Title** with _Sticker Shape_, **Key** with _sticker_shape_ and **Value** with `${start.sticker_shape}`. Click **Save**.
+4. Click **Add Field +** and fill in the **Title** with _LLM Powered Prompt_, **Key** with _llm_powered_prompt_ and **Value** with `${openai_0.output.texts}`. Click **Save**.
+5. Click **Add Field +** and fill in the **Title** with _Digital Sticker_, **Key** with _digital_sticker_ and **Value** with `${stability_0.output.images}`. Click **Save**.
 
 You will see that the End operator is automatically linked to multiple components: `start`, `openai_0` and `stability_0`.
 

--- a/docs/v0.10.0-beta/quickstart.zh_CN.mdx
+++ b/docs/v0.10.0-beta/quickstart.zh_CN.mdx
@@ -120,13 +120,13 @@ You are a prompt engineer to generate Stable Diffusion prompts to generate stick
 7. In the **Prompt** field, specify the text prompt to generate an LLM augmented prompt:
 
 ```
-Augment the prompt with descriptive details for generating sticker images, and add the styles exactly at the end of the prompt "sticker style, flat icon, vector, die-cut {{start.shape}} sticker with white border".
+Augment the prompt with descriptive details for generating sticker images, and add the styles exactly at the end of the prompt "sticker style, flat icon, vector, die-cut ${start.shape} sticker with white border".
 
 Prompt: a bear
-Output: a brown bear dancing in a forest, sticker style, flat icon, vector, die-cut {{start.shape}} sticker with white border
+Output: a brown bear dancing in a forest, sticker style, flat icon, vector, die-cut ${start.shape} sticker with white border
 Prompt: a dog writes code
-Output: a dog writes code in front of a laptop and drinks coffee, sticker style, flat icon, vector, die-cut {{start.shape}} sticker with white border
-Prompt: {{start.prompt}}
+Output: a dog writes code in front of a laptop and drinks coffee, sticker style, flat icon, vector, die-cut ${start.shape} sticker with white border
+Prompt: ${start.prompt}
 Output:
 ```
 
@@ -134,8 +134,8 @@ Output:
 9. Click **Save**.
 
 The OpenAI connector will automatically link to the Start operator
-since we have used `{{start.shape}}` and `{{start.prompt}}` in the OpenAI connector configuration.
-The `{{}}` placeholders represent **string values** to be filled during pipeline triggering.
+since we have used `${start.shape}` and `${start.prompt}` in the OpenAI connector configuration.
+The `${}` placeholders represent **string values** to be filled during pipeline triggering.
 
 To set up an Stability AI connector:
 
@@ -144,18 +144,18 @@ To set up an Stability AI connector:
 3. Select _TASK_TEXT_TO_IMAGE_ from the dropdown of the **Task** field.
 4. Adjust **CFG Scale** to control how strictly the diffusion process adheres to the text prompt, e.g., set it to _8_.
 5. Choose the **Engine** to use, e.g., _stable-diffusion-xl-1024-v1-0_.
-6. In the **Prompts** field, specify the generated text array from the OpenAI connector output `{ai_0.output.texts}`.
+6. In the **Prompts** field, specify the generated text array from the OpenAI connector output `${ai_0.output.texts}`.
 7. Set **Samples** to _1_ to indicate generating only one image.
 8. Specify a **Seed** with _0_ for a randomization.
 9. Fill **Steps** to _30_ to indicate the number of diffusion steps to run.
 10. Click **Save**.
 
 You will see that the Stability AI connector is automatically linked to the OpenAI connector
-since we have used `{ai_0.output.texts}` in the Stability AI connector configuration.
+since we have used `${ai_0.output.texts}` in the Stability AI connector configuration.
 
 <InfoBlock type="tip" title="Tip">
-  The `{}` placeholders are used to reference values from previous connectors.
-  Unlike the `{{}}` placeholders, `{}` retains the type of the referenced value.
+  The `${}` placeholders are used to reference values from previous connectors.
+  Unlike the `${}` placeholders, `${}` retains the type of the referenced value.
 </InfoBlock>
 
 The End Operator is used at the end of a VDP pipeline to receive the output as a response when triggering the pipeline.
@@ -163,10 +163,10 @@ The End Operator is used at the end of a VDP pipeline to receive the output as a
 To set up an End operator:
 
 1. Find the **end** operator on canvas.
-2. Click **Add Field +** and fill in the **Title** with _My Original Prompt_, **Key** with _my_original_prompt_ and **Value** with `{start.prompt}`.
-3. Click **Add Field +** and fill in the **Title** with _Sticker Shape_, **Key** with _sticker_shape_ and **Value** with `{start.shape}`.
-4. Click **Add Field +** and fill in the **Title** with _LLM Powered Prompt_, **Key** with _llm_powered_prompt_ and **Value** with `{ai_0.output.texts}`.
-5. Click **Add Field +** and fill in the **Title** with _Digital Sticker_, **Key** with _digital_sticker_ and **Value** with `{ai_0.output.images}`.
+2. Click **Add Field +** and fill in the **Title** with _My Original Prompt_, **Key** with _my_original_prompt_ and **Value** with `${start.prompt}`.
+3. Click **Add Field +** and fill in the **Title** with _Sticker Shape_, **Key** with _sticker_shape_ and **Value** with `${start.shape}`.
+4. Click **Add Field +** and fill in the **Title** with _LLM Powered Prompt_, **Key** with _llm_powered_prompt_ and **Value** with `${ai_0.output.texts}`.
+5. Click **Add Field +** and fill in the **Title** with _Digital Sticker_, **Key** with _digital_sticker_ and **Value** with `${ai_0.output.images}`.
 6. Click **Save**.
 
 You will see that the End operator is automatically linked to multiple components: `start`, `ai_0` and `ai_1`.

--- a/docs/v0.10.0-beta/sdk/python.en.mdx
+++ b/docs/v0.10.0-beta/sdk/python.en.mdx
@@ -405,7 +405,7 @@ Now we can create a `model` `component`. From the already defined `instill Model
 instill_model_input = instill_task_detection_input.Input(
   model_namespace="admin",
   model_id="yolov7",
-  image_base64="{start.input_image}",
+  image_base64="${start.input_image}",
 )
 # create model connector component from the connector resource we had created previously
 instill_model_connector_component = instill_model.create_component(
@@ -419,7 +419,7 @@ Finally, we create an end operator.
 ```python
 # define end operator input and metadata spec
 end_operator_inp = {}
-end_operator_inp.update({"inference_result": "{yolov7.output.objects}"})
+end_operator_inp.update({"inference_result": "${yolov7.output.objects}"})
 
 end_operator_metadata = {}
 end_operator_metadata.update(

--- a/docs/v0.10.0-beta/sdk/python.zh_CN.mdx
+++ b/docs/v0.10.0-beta/sdk/python.zh_CN.mdx
@@ -405,7 +405,7 @@ Now we can create a `model` `component`. From the already defined `instill Model
 instill_model_input = instill_task_detection_input.Input(
   model_namespace="admin",
   model_id="yolov7",
-  image_base64="{start.input_image}",
+  image_base64="${start.input_image}",
 )
 # create model connector component from the connector resource we had created previously
 instill_model_connector_component = instill_model.create_component(
@@ -419,7 +419,7 @@ Finally, we create an end operator.
 ```python
 # define end operator input and metadata spec
 end_operator_inp = {}
-end_operator_inp.update({"inference_result": "{yolov7.output.objects}"})
+end_operator_inp.update({"inference_result": "${yolov7.output.objects}"})
 
 end_operator_metadata = {}
 end_operator_metadata.update(

--- a/docs/v0.10.0-beta/vdp/app-connectors/numbers-protocol.en.mdx
+++ b/docs/v0.10.0-beta/vdp/app-connectors/numbers-protocol.en.mdx
@@ -102,7 +102,7 @@ This is a sample `configuration` in the pipeline recipe.
 {
   "configuration": {
     "input": {
-      "images": ["{ start.image }", "/9j/xxxx"],
+      "images": ["${ start.image }", "/9j/xxxx"],
       "asset_creator": "Xiaofei Du",
       "abstract": "Xiaofei's Web3 creation",
       "custom": {

--- a/docs/v0.10.0-beta/vdp/app-connectors/numbers-protocol.zh_CN.mdx
+++ b/docs/v0.10.0-beta/vdp/app-connectors/numbers-protocol.zh_CN.mdx
@@ -102,7 +102,7 @@ This is a sample `configuration` in the pipeline recipe.
 {
   "configuration": {
     "input": {
-      "images": ["{ start.image }", "/9j/xxxx"],
+      "images": ["${ start.image }", "/9j/xxxx"],
       "asset_creator": "Xiaofei Du",
       "abstract": "Xiaofei's Web3 creation",
       "custom": {

--- a/docs/v0.10.0-beta/vdp/data-connectors/airbyte.en.mdx
+++ b/docs/v0.10.0-beta/vdp/data-connectors/airbyte.en.mdx
@@ -70,8 +70,8 @@ This is a sample `configuration` in the pipeline recipe.
 {
   "configuration": {
     "input": {
-      "a_text_field": "{ start.prompt }",
-      "a_object_field": "{ compA.object }"
+      "a_text_field": "${ start.prompt }",
+      "a_object_field": "${ compA.object }"
     }
   }
 }

--- a/docs/v0.10.0-beta/vdp/data-connectors/airbyte.zh_CN.mdx
+++ b/docs/v0.10.0-beta/vdp/data-connectors/airbyte.zh_CN.mdx
@@ -70,8 +70,8 @@ This is a sample `configuration` in the pipeline recipe.
 {
   "configuration": {
     "input": {
-      "a_text_field": "{ start.prompt }",
-      "a_object_field": "{ compA.object }"
+      "a_text_field": "${ start.prompt }",
+      "a_object_field": "${ compA.object }"
     }
   }
 }

--- a/docs/v0.10.0-beta/vdp/operators/base64.en.mdx
+++ b/docs/v0.10.0-beta/vdp/operators/base64.en.mdx
@@ -30,7 +30,7 @@ This is a sample `configuration` in the pipeline recipe.
 {
   "configuration": {
     "task": "TASK_ENCODE",
-    "data": "{ start.data }"
+    "data": "${ start.data }"
   }
 }
 ```

--- a/docs/v0.10.0-beta/vdp/operators/base64.zh_CN.mdx
+++ b/docs/v0.10.0-beta/vdp/operators/base64.zh_CN.mdx
@@ -30,7 +30,7 @@ This is a sample `configuration` in the pipeline recipe.
 {
   "configuration": {
     "task": "TASK_ENCODE",
-    "data": "{ start.data }"
+    "data": "${ start.data }"
   }
 }
 ```

--- a/docs/v0.10.0-beta/vdp/operators/json.en.mdx
+++ b/docs/v0.10.0-beta/vdp/operators/json.en.mdx
@@ -31,8 +31,8 @@ This is a sample `configuration` in the pipeline recipe.
 {
   "configuration": {
     "task": "TASK_GET_VALUE",
-    "json_string": "{ start.json_string }",
-    "path": "{ start.path }"
+    "json_string": "${ start.json_string }",
+    "path": "${ start.path }"
   }
 }
 ```

--- a/docs/v0.10.0-beta/vdp/operators/json.zh_CN.mdx
+++ b/docs/v0.10.0-beta/vdp/operators/json.zh_CN.mdx
@@ -31,8 +31,8 @@ This is a sample `configuration` in the pipeline recipe.
 {
   "configuration": {
     "task": "TASK_GET_VALUE",
-    "json_string": "{ start.json_string }",
-    "path": "{ start.path }"
+    "json_string": "${ start.json_string }",
+    "path": "${ start.path }"
   }
 }
 ```

--- a/docs/v0.10.0-beta/vdp/operators/rest.en.mdx
+++ b/docs/v0.10.0-beta/vdp/operators/rest.en.mdx
@@ -33,9 +33,9 @@ This is a sample `configuration` in the pipeline recipe.
 {
   "configuration": {
     "task": "TASK_CALL_ENDPOINT",
-    "url": "{ start.url }",
-    "method": "{ start.method }",
-    "request_body": "{ start.body}"
+    "url": "${ start.url }",
+    "method": "${ start.method }",
+    "request_body": "${ start.body}"
   }
 }
 ```

--- a/docs/v0.10.0-beta/vdp/operators/rest.zh_CN.mdx
+++ b/docs/v0.10.0-beta/vdp/operators/rest.zh_CN.mdx
@@ -33,9 +33,9 @@ This is a sample `configuration` in the pipeline recipe.
 {
   "configuration": {
     "task": "TASK_CALL_ENDPOINT",
-    "url": "{ start.url }",
-    "method": "{ start.method }",
-    "request_body": "{ start.body}"
+    "url": "${ start.url }",
+    "method": "${ start.method }",
+    "request_body": "${ start.body}"
   }
 }
 ```

--- a/docs/v0.10.0-beta/vdp/operators/textextraction.en.mdx
+++ b/docs/v0.10.0-beta/vdp/operators/textextraction.en.mdx
@@ -32,7 +32,7 @@ This is a sample `configuration` in the pipeline recipe.
 {
   "configuration": {
     "task": "TASK_EXTRACT_FROM_PATH",
-    "path": "{ start.path }"
+    "path": "${ start.path }"
   }
 }
 ```

--- a/docs/v0.10.0-beta/vdp/operators/textextraction.zh_CN.mdx
+++ b/docs/v0.10.0-beta/vdp/operators/textextraction.zh_CN.mdx
@@ -32,7 +32,7 @@ This is a sample `configuration` in the pipeline recipe.
 {
   "configuration": {
     "task": "TASK_EXTRACT_FROM_PATH",
-    "path": "{ start.path }"
+    "path": "${ start.path }"
   }
 }
 ```


### PR DESCRIPTION
Because

- We've updated the pipeline reference syntax in Core v0.10.0-beta. But the website still use old syntax.

This commit

- Update reference syntax in v0.10.0-beta document
