### PR TITLE
docs: namananand/ins 3306 use new namespace from @instill-ai/typescript-sdk to instill-sdk

### DIFF
--- a/docs/v0.10.0-beta/sdk/typescript.en.mdx
+++ b/docs/v0.10.0-beta/sdk/typescript.en.mdx
@@ -21,15 +21,15 @@ description: "Welcome to Instill SDK - Where the world of AI-first applications 
 <CH.Code>
 
 ```shellscript npm
-npm i @instill-ai/typescript-sdk
+npm i instill-sdk
 ```
 
 ```shellscript yarn
-yarn add @instill-ai/typescript-sdk
+yarn add instill-sdk
 ```
 
 ```shellscript pnpm
-pnpm add @instill-ai/typescript-sdk
+pnpm add instill-sdk
 ```
 
 </CH.Code>

--- a/docs/v0.10.0-beta/sdk/typescript.en.mdx
+++ b/docs/v0.10.0-beta/sdk/typescript.en.mdx
@@ -39,11 +39,11 @@ pnpm add @instill-ai/typescript-sdk
 <CH.Code>
 
 ```typescript next.js
-import InstillClient from "@instill-ai/typescript-sdk";
+import InstillClient from "instill-sdk";
 ```
 
 ```typescript node.js
-const InstillClient = require("@instill-ai/typescript-sdk").default;
+const InstillClient = require("instill-sdk").default;
 ```
 
 </CH.Code>
@@ -88,7 +88,7 @@ const client = new InstillClient(
 
 ```typescript
 import { useEffect, useState } from "react";
-import InstillClient, { User } from "@instill-ai/typescript-sdk";
+import InstillClient, { User } from "instill-sdk";
 
 export default function TypescriptSdkDemo() {
   const [user, setUser] = useState<User[]>([]);
@@ -131,7 +131,7 @@ export default function TypescriptSdkDemo() {
 
 ```typescript
 import { useEffect, useState } from "react";
-import InstillClient, { User } from "@instill-ai/typescript-sdk";
+import InstillClient, { User } from "instill-sdk";
 
 export default function TypescriptSdkDemo() {
   const [user, setUser] = useState<User[]>([]);

--- a/docs/v0.10.0-beta/sdk/typescript.zh_CN.mdx
+++ b/docs/v0.10.0-beta/sdk/typescript.zh_CN.mdx
@@ -21,15 +21,15 @@ description: "Welcome to Instill SDK - Where the world of AI-first applications 
 <CH.Code>
 
 ```shellscript npm
-npm i @instill-ai/typescript-sdk
+npm i instill-sdk
 ```
 
 ```shellscript yarn
-yarn add @instill-ai/typescript-sdk
+yarn add instill-sdk
 ```
 
 ```shellscript pnpm
-pnpm add @instill-ai/typescript-sdk
+pnpm add instill-sdk
 ```
 
 </CH.Code>

--- a/docs/v0.10.0-beta/sdk/typescript.zh_CN.mdx
+++ b/docs/v0.10.0-beta/sdk/typescript.zh_CN.mdx
@@ -39,11 +39,11 @@ pnpm add @instill-ai/typescript-sdk
 <CH.Code>
 
 ```typescript next.js
-import InstillClient from "@instill-ai/typescript-sdk";
+import InstillClient from "instill-sdk";
 ```
 
 ```typescript node.js
-const InstillClient = require("@instill-ai/typescript-sdk").default;
+const InstillClient = require("instill-sdk").default;
 ```
 
 </CH.Code>
@@ -88,7 +88,7 @@ const client = new InstillClient(
 
 ```typescript
 import { useEffect, useState } from "react";
-import InstillClient, { User } from "@instill-ai/typescript-sdk";
+import InstillClient, { User } from "instill-sdk";
 
 export default function TypescriptSdkDemo() {
   const [user, setUser] = useState<User[]>([]);
@@ -131,7 +131,7 @@ export default function TypescriptSdkDemo() {
 
 ```typescript
 import { useEffect, useState } from "react";
-import InstillClient, { User } from "@instill-ai/typescript-sdk";
+import InstillClient, { User } from "instill-sdk";
 
 export default function TypescriptSdkDemo() {
   const [user, setUser] = useState<User[]>([]);

--- a/docs/v0.4.1-alpha/sdk/typescript.en.mdx
+++ b/docs/v0.4.1-alpha/sdk/typescript.en.mdx
@@ -21,15 +21,15 @@ description: "Welcome to Instill SDK - Where the world of AI-first applications 
 <CH.Code>
 
 ```shellscript npm
-npm i @instill-ai/typescript-sdk
+npm i instill-sdk
 ```
 
 ```shellscript yarn
-yarn add @instill-ai/typescript-sdk
+yarn add instill-sdk
 ```
 
 ```shellscript pnpm
-pnpm add @instill-ai/typescript-sdk
+pnpm add instill-sdk
 ```
 
 </CH.Code>

--- a/docs/v0.4.1-alpha/sdk/typescript.en.mdx
+++ b/docs/v0.4.1-alpha/sdk/typescript.en.mdx
@@ -39,11 +39,11 @@ pnpm add @instill-ai/typescript-sdk
 <CH.Code>
 
 ```typescript next.js
-import InstillClient from "@instill-ai/typescript-sdk";
+import InstillClient from "instill-sdk";
 ```
 
 ```typescript node.js
-const InstillClient = require("@instill-ai/typescript-sdk").default;
+const InstillClient = require("instill-sdk").default;
 ```
 
 </CH.Code>
@@ -92,7 +92,7 @@ const client = new InstillClient(
 
 ```typescript Instill-Cloud
 import { useEffect, useState } from "react";
-import InstillClient, { User } from "@instill-ai/typescript-sdk";
+import InstillClient, { User } from "instill-sdk";
 
 export default function TypescriptSdkDemo() {
   const [user, setUser] = useState<User[]>([]);
@@ -133,7 +133,7 @@ export default function TypescriptSdkDemo() {
 
 ```typescript Instill-Core
 import { useEffect, useState } from "react";
-import InstillClient, { User } from "@instill-ai/typescript-sdk";
+import InstillClient, { User } from "instill-sdk";
 
 export default function TypescriptSdkDemo() {
   const [user, setUser] = useState<User[]>([]);

--- a/docs/v0.4.1-alpha/sdk/typescript.zh_CN.mdx
+++ b/docs/v0.4.1-alpha/sdk/typescript.zh_CN.mdx
@@ -21,15 +21,15 @@ description: "Welcome to Instill SDK - Where the world of AI-first applications 
 <CH.Code>
 
 ```shellscript npm
-npm i @instill-ai/typescript-sdk
+npm i instill-sdk
 ```
 
 ```shellscript yarn
-yarn add @instill-ai/typescript-sdk
+yarn add instill-sdk
 ```
 
 ```shellscript pnpm
-pnpm add @instill-ai/typescript-sdk
+pnpm add instill-sdk
 ```
 
 </CH.Code>

--- a/docs/v0.4.1-alpha/sdk/typescript.zh_CN.mdx
+++ b/docs/v0.4.1-alpha/sdk/typescript.zh_CN.mdx
@@ -39,11 +39,11 @@ pnpm add @instill-ai/typescript-sdk
 <CH.Code>
 
 ```typescript next.js
-import InstillClient from "@instill-ai/typescript-sdk";
+import InstillClient from "instill-sdk";
 ```
 
 ```typescript node.js
-const InstillClient = require("@instill-ai/typescript-sdk").default;
+const InstillClient = require("instill-sdk").default;
 ```
 
 </CH.Code>
@@ -92,7 +92,7 @@ const client = new InstillClient(
 
 ```typescript Instill-Cloud
 import { useEffect, useState } from "react";
-import InstillClient, { User } from "@instill-ai/typescript-sdk";
+import InstillClient, { User } from "instill-sdk";
 
 export default function TypescriptSdkDemo() {
   const [user, setUser] = useState<User[]>([]);
@@ -133,7 +133,7 @@ export default function TypescriptSdkDemo() {
 
 ```typescript Instill-Core
 import { useEffect, useState } from "react";
-import InstillClient, { User } from "@instill-ai/typescript-sdk";
+import InstillClient, { User } from "instill-sdk";
 
 export default function TypescriptSdkDemo() {
   const [user, setUser] = useState<User[]>([]);

--- a/docs/v0.5.0-alpha/sdk/typescript.en.mdx
+++ b/docs/v0.5.0-alpha/sdk/typescript.en.mdx
@@ -21,15 +21,15 @@ description: "Welcome to Instill SDK - Where the world of AI-first applications 
 <CH.Code>
 
 ```shellscript npm
-npm i @instill-ai/typescript-sdk
+npm i instill-sdk
 ```
 
 ```shellscript yarn
-yarn add @instill-ai/typescript-sdk
+yarn add instill-sdk
 ```
 
 ```shellscript pnpm
-pnpm add @instill-ai/typescript-sdk
+pnpm add instill-sdk
 ```
 
 </CH.Code>

--- a/docs/v0.5.0-alpha/sdk/typescript.en.mdx
+++ b/docs/v0.5.0-alpha/sdk/typescript.en.mdx
@@ -39,11 +39,11 @@ pnpm add @instill-ai/typescript-sdk
 <CH.Code>
 
 ```typescript next.js
-import InstillClient from "@instill-ai/typescript-sdk";
+import InstillClient from "instill-sdk";
 ```
 
 ```typescript node.js
-const InstillClient = require("@instill-ai/typescript-sdk").default;
+const InstillClient = require("instill-sdk").default;
 ```
 
 </CH.Code>
@@ -88,7 +88,7 @@ const client = new InstillClient(
 
 ```typescript
 import { useEffect, useState } from "react";
-import InstillClient, { User } from "@instill-ai/typescript-sdk";
+import InstillClient, { User } from "instill-sdk";
 
 export default function TypescriptSdkDemo() {
   const [user, setUser] = useState<User[]>([]);
@@ -131,7 +131,7 @@ export default function TypescriptSdkDemo() {
 
 ```typescript
 import { useEffect, useState } from "react";
-import InstillClient, { User } from "@instill-ai/typescript-sdk";
+import InstillClient, { User } from "instill-sdk";
 
 export default function TypescriptSdkDemo() {
   const [user, setUser] = useState<User[]>([]);

--- a/docs/v0.5.0-alpha/sdk/typescript.zh_CN.mdx
+++ b/docs/v0.5.0-alpha/sdk/typescript.zh_CN.mdx
@@ -21,15 +21,15 @@ description: "Welcome to Instill SDK - Where the world of AI-first applications 
 <CH.Code>
 
 ```shellscript npm
-npm i @instill-ai/typescript-sdk
+npm i instill-sdk
 ```
 
 ```shellscript yarn
-yarn add @instill-ai/typescript-sdk
+yarn add instill-sdk
 ```
 
 ```shellscript pnpm
-pnpm add @instill-ai/typescript-sdk
+pnpm add instill-sdk
 ```
 
 </CH.Code>

--- a/docs/v0.5.0-alpha/sdk/typescript.zh_CN.mdx
+++ b/docs/v0.5.0-alpha/sdk/typescript.zh_CN.mdx
@@ -39,11 +39,11 @@ pnpm add @instill-ai/typescript-sdk
 <CH.Code>
 
 ```typescript next.js
-import InstillClient from "@instill-ai/typescript-sdk";
+import InstillClient from "instill-sdk";
 ```
 
 ```typescript node.js
-const InstillClient = require("@instill-ai/typescript-sdk").default;
+const InstillClient = require("instill-sdk").default;
 ```
 
 </CH.Code>
@@ -88,7 +88,7 @@ const client = new InstillClient(
 
 ```typescript
 import { useEffect, useState } from "react";
-import InstillClient, { User } from "@instill-ai/typescript-sdk";
+import InstillClient, { User } from "instill-sdk";
 
 export default function TypescriptSdkDemo() {
   const [user, setUser] = useState<User[]>([]);
@@ -131,7 +131,7 @@ export default function TypescriptSdkDemo() {
 
 ```typescript
 import { useEffect, useState } from "react";
-import InstillClient, { User } from "@instill-ai/typescript-sdk";
+import InstillClient, { User } from "instill-sdk";
 
 export default function TypescriptSdkDemo() {
   const [user, setUser] = useState<User[]>([]);

--- a/docs/v0.6.0-alpha/sdk/typescript.en.mdx
+++ b/docs/v0.6.0-alpha/sdk/typescript.en.mdx
@@ -21,15 +21,15 @@ description: "Welcome to Instill SDK - Where the world of AI-first applications 
 <CH.Code>
 
 ```shellscript npm
-npm i @instill-ai/typescript-sdk
+npm i instill-sdk
 ```
 
 ```shellscript yarn
-yarn add @instill-ai/typescript-sdk
+yarn add instill-sdk
 ```
 
 ```shellscript pnpm
-pnpm add @instill-ai/typescript-sdk
+pnpm add instill-sdk
 ```
 
 </CH.Code>

--- a/docs/v0.6.0-alpha/sdk/typescript.en.mdx
+++ b/docs/v0.6.0-alpha/sdk/typescript.en.mdx
@@ -39,11 +39,11 @@ pnpm add @instill-ai/typescript-sdk
 <CH.Code>
 
 ```typescript next.js
-import InstillClient from "@instill-ai/typescript-sdk";
+import InstillClient from "instill-sdk";
 ```
 
 ```typescript node.js
-const InstillClient = require("@instill-ai/typescript-sdk").default;
+const InstillClient = require("instill-sdk").default;
 ```
 
 </CH.Code>
@@ -88,7 +88,7 @@ const client = new InstillClient(
 
 ```typescript
 import { useEffect, useState } from "react";
-import InstillClient, { User } from "@instill-ai/typescript-sdk";
+import InstillClient, { User } from "instill-sdk";
 
 export default function TypescriptSdkDemo() {
   const [user, setUser] = useState<User[]>([]);
@@ -131,7 +131,7 @@ export default function TypescriptSdkDemo() {
 
 ```typescript
 import { useEffect, useState } from "react";
-import InstillClient, { User } from "@instill-ai/typescript-sdk";
+import InstillClient, { User } from "instill-sdk";
 
 export default function TypescriptSdkDemo() {
   const [user, setUser] = useState<User[]>([]);

--- a/docs/v0.6.0-alpha/sdk/typescript.zh_CN.mdx
+++ b/docs/v0.6.0-alpha/sdk/typescript.zh_CN.mdx
@@ -21,15 +21,15 @@ description: "Welcome to Instill SDK - Where the world of AI-first applications 
 <CH.Code>
 
 ```shellscript npm
-npm i @instill-ai/typescript-sdk
+npm i instill-sdk
 ```
 
 ```shellscript yarn
-yarn add @instill-ai/typescript-sdk
+yarn add instill-sdk
 ```
 
 ```shellscript pnpm
-pnpm add @instill-ai/typescript-sdk
+pnpm add instill-sdk
 ```
 
 </CH.Code>

--- a/docs/v0.6.0-alpha/sdk/typescript.zh_CN.mdx
+++ b/docs/v0.6.0-alpha/sdk/typescript.zh_CN.mdx
@@ -39,11 +39,11 @@ pnpm add @instill-ai/typescript-sdk
 <CH.Code>
 
 ```typescript next.js
-import InstillClient from "@instill-ai/typescript-sdk";
+import InstillClient from "instill-sdk";
 ```
 
 ```typescript node.js
-const InstillClient = require("@instill-ai/typescript-sdk").default;
+const InstillClient = require("instill-sdk").default;
 ```
 
 </CH.Code>
@@ -88,7 +88,7 @@ const client = new InstillClient(
 
 ```typescript
 import { useEffect, useState } from "react";
-import InstillClient, { User } from "@instill-ai/typescript-sdk";
+import InstillClient, { User } from "instill-sdk";
 
 export default function TypescriptSdkDemo() {
   const [user, setUser] = useState<User[]>([]);
@@ -131,7 +131,7 @@ export default function TypescriptSdkDemo() {
 
 ```typescript
 import { useEffect, useState } from "react";
-import InstillClient, { User } from "@instill-ai/typescript-sdk";
+import InstillClient, { User } from "instill-sdk";
 
 export default function TypescriptSdkDemo() {
   const [user, setUser] = useState<User[]>([]);

--- a/docs/v0.8.0-beta/sdk/typescript.en.mdx
+++ b/docs/v0.8.0-beta/sdk/typescript.en.mdx
@@ -21,15 +21,15 @@ description: "Welcome to Instill SDK - Where the world of AI-first applications 
 <CH.Code>
 
 ```shellscript npm
-npm i @instill-ai/typescript-sdk
+npm i instill-sdk
 ```
 
 ```shellscript yarn
-yarn add @instill-ai/typescript-sdk
+yarn add instill-sdk
 ```
 
 ```shellscript pnpm
-pnpm add @instill-ai/typescript-sdk
+pnpm add instill-sdk
 ```
 
 </CH.Code>

--- a/docs/v0.8.0-beta/sdk/typescript.en.mdx
+++ b/docs/v0.8.0-beta/sdk/typescript.en.mdx
@@ -39,11 +39,11 @@ pnpm add @instill-ai/typescript-sdk
 <CH.Code>
 
 ```typescript next.js
-import InstillClient from "@instill-ai/typescript-sdk";
+import InstillClient from "instill-sdk";
 ```
 
 ```typescript node.js
-const InstillClient = require("@instill-ai/typescript-sdk").default;
+const InstillClient = require("instill-sdk").default;
 ```
 
 </CH.Code>
@@ -88,7 +88,7 @@ const client = new InstillClient(
 
 ```typescript
 import { useEffect, useState } from "react";
-import InstillClient, { User } from "@instill-ai/typescript-sdk";
+import InstillClient, { User } from "instill-sdk";
 
 export default function TypescriptSdkDemo() {
   const [user, setUser] = useState<User[]>([]);
@@ -131,7 +131,7 @@ export default function TypescriptSdkDemo() {
 
 ```typescript
 import { useEffect, useState } from "react";
-import InstillClient, { User } from "@instill-ai/typescript-sdk";
+import InstillClient, { User } from "instill-sdk";
 
 export default function TypescriptSdkDemo() {
   const [user, setUser] = useState<User[]>([]);

--- a/docs/v0.8.0-beta/sdk/typescript.zh_CN.mdx
+++ b/docs/v0.8.0-beta/sdk/typescript.zh_CN.mdx
@@ -21,15 +21,15 @@ description: "Welcome to Instill SDK - Where the world of AI-first applications 
 <CH.Code>
 
 ```shellscript npm
-npm i @instill-ai/typescript-sdk
+npm i instill-sdk
 ```
 
 ```shellscript yarn
-yarn add @instill-ai/typescript-sdk
+yarn add instill-sdk
 ```
 
 ```shellscript pnpm
-pnpm add @instill-ai/typescript-sdk
+pnpm add instill-sdk
 ```
 
 </CH.Code>

--- a/docs/v0.8.0-beta/sdk/typescript.zh_CN.mdx
+++ b/docs/v0.8.0-beta/sdk/typescript.zh_CN.mdx
@@ -39,11 +39,11 @@ pnpm add @instill-ai/typescript-sdk
 <CH.Code>
 
 ```typescript next.js
-import InstillClient from "@instill-ai/typescript-sdk";
+import InstillClient from "instill-sdk";
 ```
 
 ```typescript node.js
-const InstillClient = require("@instill-ai/typescript-sdk").default;
+const InstillClient = require("instill-sdk").default;
 ```
 
 </CH.Code>
@@ -88,7 +88,7 @@ const client = new InstillClient(
 
 ```typescript
 import { useEffect, useState } from "react";
-import InstillClient, { User } from "@instill-ai/typescript-sdk";
+import InstillClient, { User } from "instill-sdk";
 
 export default function TypescriptSdkDemo() {
   const [user, setUser] = useState<User[]>([]);
@@ -131,7 +131,7 @@ export default function TypescriptSdkDemo() {
 
 ```typescript
 import { useEffect, useState } from "react";
-import InstillClient, { User } from "@instill-ai/typescript-sdk";
+import InstillClient, { User } from "instill-sdk";
 
 export default function TypescriptSdkDemo() {
   const [user, setUser] = useState<User[]>([]);

--- a/docs/v0.9.0-beta/sdk/typescript.en.mdx
+++ b/docs/v0.9.0-beta/sdk/typescript.en.mdx
@@ -21,15 +21,15 @@ description: "Welcome to Instill SDK - Where the world of AI-first applications 
 <CH.Code>
 
 ```shellscript npm
-npm i @instill-ai/typescript-sdk
+npm i instill-sdk
 ```
 
 ```shellscript yarn
-yarn add @instill-ai/typescript-sdk
+yarn add instill-sdk
 ```
 
 ```shellscript pnpm
-pnpm add @instill-ai/typescript-sdk
+pnpm add instill-sdk
 ```
 
 </CH.Code>

--- a/docs/v0.9.0-beta/sdk/typescript.en.mdx
+++ b/docs/v0.9.0-beta/sdk/typescript.en.mdx
@@ -39,11 +39,11 @@ pnpm add @instill-ai/typescript-sdk
 <CH.Code>
 
 ```typescript next.js
-import InstillClient from "@instill-ai/typescript-sdk";
+import InstillClient from "instill-sdk";
 ```
 
 ```typescript node.js
-const InstillClient = require("@instill-ai/typescript-sdk").default;
+const InstillClient = require("instill-sdk").default;
 ```
 
 </CH.Code>
@@ -88,7 +88,7 @@ const client = new InstillClient(
 
 ```typescript
 import { useEffect, useState } from "react";
-import InstillClient, { User } from "@instill-ai/typescript-sdk";
+import InstillClient, { User } from "instill-sdk";
 
 export default function TypescriptSdkDemo() {
   const [user, setUser] = useState<User[]>([]);
@@ -131,7 +131,7 @@ export default function TypescriptSdkDemo() {
 
 ```typescript
 import { useEffect, useState } from "react";
-import InstillClient, { User } from "@instill-ai/typescript-sdk";
+import InstillClient, { User } from "instill-sdk";
 
 export default function TypescriptSdkDemo() {
   const [user, setUser] = useState<User[]>([]);

--- a/docs/v0.9.0-beta/sdk/typescript.zh_CN.mdx
+++ b/docs/v0.9.0-beta/sdk/typescript.zh_CN.mdx
@@ -21,15 +21,15 @@ description: "Welcome to Instill SDK - Where the world of AI-first applications 
 <CH.Code>
 
 ```shellscript npm
-npm i @instill-ai/typescript-sdk
+npm i instill-sdk
 ```
 
 ```shellscript yarn
-yarn add @instill-ai/typescript-sdk
+yarn add instill-sdk
 ```
 
 ```shellscript pnpm
-pnpm add @instill-ai/typescript-sdk
+pnpm add instill-sdk
 ```
 
 </CH.Code>

--- a/docs/v0.9.0-beta/sdk/typescript.zh_CN.mdx
+++ b/docs/v0.9.0-beta/sdk/typescript.zh_CN.mdx
@@ -39,11 +39,11 @@ pnpm add @instill-ai/typescript-sdk
 <CH.Code>
 
 ```typescript next.js
-import InstillClient from "@instill-ai/typescript-sdk";
+import InstillClient from "instill-sdk";
 ```
 
 ```typescript node.js
-const InstillClient = require("@instill-ai/typescript-sdk").default;
+const InstillClient = require("instill-sdk").default;
 ```
 
 </CH.Code>
@@ -88,7 +88,7 @@ const client = new InstillClient(
 
 ```typescript
 import { useEffect, useState } from "react";
-import InstillClient, { User } from "@instill-ai/typescript-sdk";
+import InstillClient, { User } from "instill-sdk";
 
 export default function TypescriptSdkDemo() {
   const [user, setUser] = useState<User[]>([]);
@@ -131,7 +131,7 @@ export default function TypescriptSdkDemo() {
 
 ```typescript
 import { useEffect, useState } from "react";
-import InstillClient, { User } from "@instill-ai/typescript-sdk";
+import InstillClient, { User } from "instill-sdk";
 
 export default function TypescriptSdkDemo() {
   const [user, setUser] = useState<User[]>([]);

--- a/src/components/landing/HowItWorks/HowItWorks.tsx
+++ b/src/components/landing/HowItWorks/HowItWorks.tsx
@@ -283,10 +283,10 @@ export const HowItWorks = forwardRef<HTMLDivElement, HowItWorksProps>(
                     </div>
                     <Separator className="mt-5" />
                   </div>
-                  <div className="flex flex-col items-start justify-start gap-5 px-6 py-5">
+                  <div className="flex min-w-[320px] flex-col items-start justify-start gap-5 px-6 py-5 xl:min-w-[480px]">
                     <div className="flex shrink grow basis-0 flex-col items-start justify-start gap-5 self-stretch">
                       <div className="shrink grow basis-0 font-sans text-xl font-medium text-black xl:text-[30px]">
-                        npm i @instill-ai/typescript-sdk
+                        npm i instill-sdk
                       </div>
                       <div className="inline-flex items-center justify-center gap-2 rounded py-3">
                         <Link


### PR DESCRIPTION
Because

- use new namespace from `@instill-ai/typescript-sdk` to `instill-sdk`

This commit

- use new namespace from `@instill-ai/typescript-sdk` to `instill-sdk`
