### PR TITLE
fix: fix pricing plan typo

### DIFF
--- a/src/pages/pricing.tsx
+++ b/src/pages/pricing.tsx
@@ -91,7 +91,7 @@ const PricingPage: FC & {
               features={[
                 "Unlimited public/private pipelines",
                 "Non rate-limited runs",
-                "Dedicated Slack Channel and up to 1 hour of weekly dedicated support",
+                "Community-based support on Discord",
                 "Version Control",
                 "User permissions",
                 "Upload and use your own custom models",


### PR DESCRIPTION
Because

- We have typo for our team plan

This commit

- fix pricing plan typo
