### PR TITLE
chore: update version number for docker component deployment

### DIFF
--- a/docs/v0.10.0-beta/core/deployment/docker-compose.en.mdx
+++ b/docs/v0.10.0-beta/core/deployment/docker-compose.en.mdx
@@ -32,7 +32,7 @@ Make sure you have the prerequisites set up:
 On your workstation, run:
 
 ```shellscript
-git clone -b v0.5.0-alpha https://github.com/instill-ai/core.git && cd core
+git clone -b v0.10.0-beta https://github.com/instill-ai/core.git && cd core
 make all
 ```
 

--- a/docs/v0.10.0-beta/core/deployment/docker-compose.zh_CN.mdx
+++ b/docs/v0.10.0-beta/core/deployment/docker-compose.zh_CN.mdx
@@ -32,7 +32,7 @@ Make sure you have the prerequisites set up:
 On your workstation, run:
 
 ```shellscript
-git clone -b v0.5.0-alpha https://github.com/instill-ai/core.git && cd core
+git clone -b v0.10.0-beta https://github.com/instill-ai/core.git && cd core
 make all
 ```
 

--- a/docs/v0.11.0-beta/core/deployment/docker-compose.en.mdx
+++ b/docs/v0.11.0-beta/core/deployment/docker-compose.en.mdx
@@ -32,7 +32,7 @@ Make sure you have the prerequisites set up:
 On your workstation, run:
 
 ```shellscript
-git clone -b v0.5.0-alpha https://github.com/instill-ai/core.git && cd core
+git clone -b v0.11.0-beta https://github.com/instill-ai/core.git && cd core
 make all
 ```
 

--- a/docs/v0.11.0-beta/core/deployment/docker-compose.zh_CN.mdx
+++ b/docs/v0.11.0-beta/core/deployment/docker-compose.zh_CN.mdx
@@ -32,7 +32,7 @@ Make sure you have the prerequisites set up:
 On your workstation, run:
 
 ```shellscript
-git clone -b v0.5.0-alpha https://github.com/instill-ai/core.git && cd core
+git clone -b v0.11.0-beta https://github.com/instill-ai/core.git && cd core
 make all
 ```
 

--- a/docs/v0.12.0-beta/core/deployment/docker-compose.en.mdx
+++ b/docs/v0.12.0-beta/core/deployment/docker-compose.en.mdx
@@ -32,7 +32,7 @@ Make sure you have the prerequisites set up:
 On your workstation, run:
 
 ```shellscript
-git clone -b v0.5.0-alpha https://github.com/instill-ai/core.git && cd core
+git clone -b v0.12.0-beta https://github.com/instill-ai/core.git && cd core
 make all
 ```
 

--- a/docs/v0.12.0-beta/core/deployment/docker-compose.zh_CN.mdx
+++ b/docs/v0.12.0-beta/core/deployment/docker-compose.zh_CN.mdx
@@ -32,7 +32,7 @@ Make sure you have the prerequisites set up:
 On your workstation, run:
 
 ```shellscript
-git clone -b v0.5.0-alpha https://github.com/instill-ai/core.git && cd core
+git clone -b v0.12.0-beta https://github.com/instill-ai/core.git && cd core
 make all
 ```
 

--- a/docs/v0.6.0-alpha/core/deployment/docker-compose.en.mdx
+++ b/docs/v0.6.0-alpha/core/deployment/docker-compose.en.mdx
@@ -32,7 +32,7 @@ Make sure you have the prerequisites set up:
 On your workstation, run:
 
 ```shellscript
-git clone -b v0.5.0-alpha https://github.com/instill-ai/core.git && cd core
+git clone -b v0.6.0-alpha https://github.com/instill-ai/core.git && cd core
 make all
 ```
 

--- a/docs/v0.6.0-alpha/core/deployment/docker-compose.zh_CN.mdx
+++ b/docs/v0.6.0-alpha/core/deployment/docker-compose.zh_CN.mdx
@@ -32,7 +32,7 @@ Make sure you have the prerequisites set up:
 On your workstation, run:
 
 ```shellscript
-git clone -b v0.5.0-alpha https://github.com/instill-ai/core.git && cd core
+git clone -b v0.6.0-alpha https://github.com/instill-ai/core.git && cd core
 make all
 ```
 

--- a/docs/v0.8.0-beta/core/deployment/docker-compose.en.mdx
+++ b/docs/v0.8.0-beta/core/deployment/docker-compose.en.mdx
@@ -32,7 +32,7 @@ Make sure you have the prerequisites set up:
 On your workstation, run:
 
 ```shellscript
-git clone -b v0.5.0-alpha https://github.com/instill-ai/core.git && cd core
+git clone -b v0.8.0-beta https://github.com/instill-ai/core.git && cd core
 make all
 ```
 

--- a/docs/v0.8.0-beta/core/deployment/docker-compose.zh_CN.mdx
+++ b/docs/v0.8.0-beta/core/deployment/docker-compose.zh_CN.mdx
@@ -32,7 +32,7 @@ Make sure you have the prerequisites set up:
 On your workstation, run:
 
 ```shellscript
-git clone -b v0.5.0-alpha https://github.com/instill-ai/core.git && cd core
+git clone -b v0.8.0-beta https://github.com/instill-ai/core.git && cd core
 make all
 ```
 

--- a/docs/v0.9.0-beta/core/deployment/docker-compose.en.mdx
+++ b/docs/v0.9.0-beta/core/deployment/docker-compose.en.mdx
@@ -32,7 +32,7 @@ Make sure you have the prerequisites set up:
 On your workstation, run:
 
 ```shellscript
-git clone -b v0.5.0-alpha https://github.com/instill-ai/core.git && cd core
+git clone -b v0.9.0-beta https://github.com/instill-ai/core.git && cd core
 make all
 ```
 

--- a/docs/v0.9.0-beta/core/deployment/docker-compose.zh_CN.mdx
+++ b/docs/v0.9.0-beta/core/deployment/docker-compose.zh_CN.mdx
@@ -32,7 +32,7 @@ Make sure you have the prerequisites set up:
 On your workstation, run:
 
 ```shellscript
-git clone -b v0.5.0-alpha https://github.com/instill-ai/core.git && cd core
+git clone -b v0.9.0-beta https://github.com/instill-ai/core.git && cd core
 make all
 ```
 


### PR DESCRIPTION
Because

- version number was old for docker component deployment

This commit

- update version number for docker component deployment
