### PR TITLE
chore: remove remove startConnector -> endConnector from tutorial page

### DIFF
--- a/src/components/tutorial/TutorialPipelineLabel.tsx
+++ b/src/components/tutorial/TutorialPipelineLabel.tsx
@@ -54,15 +54,6 @@ export const TutorialPipelineLabel = ({
         />
       </div>
       <div className="mb-2 flex flex-row gap-x-4">
-        <p className="bg-instillSkyBlue px-2 py-1 text-instillGrey05">
-          {sourceConnector}
-        </p>
-        <ArrowRightIcon
-          width="w-5"
-          height="h-5"
-          color="fill-instillSkyBlue"
-          position="my-auto"
-        />
         <div className="hidden flex-row gap-x-4 xl:flex">
           <TutorialLabel
             icon={
@@ -80,17 +71,7 @@ export const TutorialPipelineLabel = ({
             labelPadding="px-2 py-1"
             labelTextStyle="font-sans text-base text-instillGrey05"
           />
-          <ArrowRightIcon
-            width="w-5"
-            height="h-5"
-            color="fill-instillSkyBlue"
-            position="my-auto"
-          />
         </div>
-
-        <p className="bg-instillSkyBlue px-2 py-1 font-sans text-base text-instillGrey05">
-          {destinationConnector}
-        </p>
       </div>
     </div>
   );


### PR DESCRIPTION
Because

- remove remove startConnector -> endConnector from tutorial page

This commit

- remove remove startConnector -> endConnector from tutorial page
