### PR TITLE
docs(deployment): increase minimal memory requirement

### DIFF
--- a/docs/v0.10.0-beta/core/deployment.en.mdx
+++ b/docs/v0.10.0-beta/core/deployment.en.mdx
@@ -28,7 +28,7 @@ To achieve optimal performance, we strongly recommend configuring your Docker En
 | Docker Engine Resource | Minimal Requirements | Recommended Requirements |
 | :--------------------- | :------------------- | :----------------------- |
 | CPU Limit              | 2                    | 8                        |
-| Memory Limit           | 2 GB                 | 32 GB                    |
+| Memory Limit           | 4 GB                 | 32 GB                    |
 | Swap                   | 1 GB                 | 1 GB                     |
 | Virtual Disk Limit     | 64 GB                | 256 GB                   |
 

--- a/docs/v0.10.0-beta/core/deployment.zh_CN.mdx
+++ b/docs/v0.10.0-beta/core/deployment.zh_CN.mdx
@@ -28,7 +28,7 @@ To achieve optimal performance, we strongly recommend configuring your Docker En
 | Docker Engine Resource | Minimal Requirements | Recommended Requirements |
 | :--------------------- | :------------------- | :----------------------- |
 | CPU Limit              | 2                    | 8                        |
-| Memory Limit           | 2 GB                 | 32 GB                    |
+| Memory Limit           | 4 GB                 | 32 GB                    |
 | Swap                   | 1 GB                 | 1 GB                     |
 | Virtual Disk Limit     | 64 GB                | 256 GB                   |
 

--- a/docs/v0.11.0-beta/core/deployment.en.mdx
+++ b/docs/v0.11.0-beta/core/deployment.en.mdx
@@ -28,7 +28,7 @@ To achieve optimal performance, we strongly recommend configuring your Docker En
 | Docker Engine Resource | Minimal Requirements | Recommended Requirements |
 | :--------------------- | :------------------- | :----------------------- |
 | CPU Limit              | 2                    | 8                        |
-| Memory Limit           | 2 GB                 | 32 GB                    |
+| Memory Limit           | 4 GB                 | 32 GB                    |
 | Swap                   | 1 GB                 | 1 GB                     |
 | Virtual Disk Limit     | 64 GB                | 256 GB                   |
 

--- a/docs/v0.11.0-beta/core/deployment.zh_CN.mdx
+++ b/docs/v0.11.0-beta/core/deployment.zh_CN.mdx
@@ -28,7 +28,7 @@ To achieve optimal performance, we strongly recommend configuring your Docker En
 | Docker Engine Resource | Minimal Requirements | Recommended Requirements |
 | :--------------------- | :------------------- | :----------------------- |
 | CPU Limit              | 2                    | 8                        |
-| Memory Limit           | 2 GB                 | 32 GB                    |
+| Memory Limit           | 4 GB                 | 32 GB                    |
 | Swap                   | 1 GB                 | 1 GB                     |
 | Virtual Disk Limit     | 64 GB                | 256 GB                   |
 

--- a/docs/v0.12.0-beta/core/deployment.en.mdx
+++ b/docs/v0.12.0-beta/core/deployment.en.mdx
@@ -28,7 +28,7 @@ To achieve optimal performance, we strongly recommend configuring your Docker En
 | Docker Engine Resource | Minimal Requirements | Recommended Requirements |
 | :--------------------- | :------------------- | :----------------------- |
 | CPU Limit              | 2                    | 8                        |
-| Memory Limit           | 2 GB                 | 32 GB                    |
+| Memory Limit           | 4 GB                 | 32 GB                    |
 | Swap                   | 1 GB                 | 1 GB                     |
 | Virtual Disk Limit     | 64 GB                | 256 GB                   |
 

--- a/docs/v0.12.0-beta/core/deployment.zh_CN.mdx
+++ b/docs/v0.12.0-beta/core/deployment.zh_CN.mdx
@@ -28,7 +28,7 @@ To achieve optimal performance, we strongly recommend configuring your Docker En
 | Docker Engine Resource | Minimal Requirements | Recommended Requirements |
 | :--------------------- | :------------------- | :----------------------- |
 | CPU Limit              | 2                    | 8                        |
-| Memory Limit           | 2 GB                 | 32 GB                    |
+| Memory Limit           | 4 GB                 | 32 GB                    |
 | Swap                   | 1 GB                 | 1 GB                     |
 | Virtual Disk Limit     | 64 GB                | 256 GB                   |
 

--- a/docs/v0.4.1-alpha/core/deployment.en.mdx
+++ b/docs/v0.4.1-alpha/core/deployment.en.mdx
@@ -28,7 +28,7 @@ To achieve optimal performance, we strongly recommend configuring your Docker En
 | Docker Engine Resource | Minimal Requirements | Recommended Requirements |
 | :--------------------- | :------------------- | :----------------------- |
 | CPU Limit              | 2                    | 8                        |
-| Memory Limit           | 2 GB                 | 32 GB                    |
+| Memory Limit           | 4 GB                 | 32 GB                    |
 | Swap                   | 1 GB                 | 1 GB                     |
 | Virtual Disk Limit     | 64 GB                | 256 GB                   |
 

--- a/docs/v0.4.1-alpha/core/deployment.zh_CN.mdx
+++ b/docs/v0.4.1-alpha/core/deployment.zh_CN.mdx
@@ -28,7 +28,7 @@ To achieve optimal performance, we strongly recommend configuring your Docker En
 | Docker Engine Resource | Minimal Requirements | Recommended Requirements |
 | :--------------------- | :------------------- | :----------------------- |
 | CPU Limit              | 2                    | 8                        |
-| Memory Limit           | 2 GB                 | 32 GB                    |
+| Memory Limit           | 4 GB                 | 32 GB                    |
 | Swap                   | 1 GB                 | 1 GB                     |
 | Virtual Disk Limit     | 64 GB                | 256 GB                   |
 

--- a/docs/v0.5.0-alpha/core/deployment.en.mdx
+++ b/docs/v0.5.0-alpha/core/deployment.en.mdx
@@ -28,7 +28,7 @@ To achieve optimal performance, we strongly recommend configuring your Docker En
 | Docker Engine Resource | Minimal Requirements | Recommended Requirements |
 | :--------------------- | :------------------- | :----------------------- |
 | CPU Limit              | 2                    | 8                        |
-| Memory Limit           | 2 GB                 | 32 GB                    |
+| Memory Limit           | 4 GB                 | 32 GB                    |
 | Swap                   | 1 GB                 | 1 GB                     |
 | Virtual Disk Limit     | 64 GB                | 256 GB                   |
 

--- a/docs/v0.5.0-alpha/core/deployment.zh_CN.mdx
+++ b/docs/v0.5.0-alpha/core/deployment.zh_CN.mdx
@@ -28,7 +28,7 @@ To achieve optimal performance, we strongly recommend configuring your Docker En
 | Docker Engine Resource | Minimal Requirements | Recommended Requirements |
 | :--------------------- | :------------------- | :----------------------- |
 | CPU Limit              | 2                    | 8                        |
-| Memory Limit           | 2 GB                 | 32 GB                    |
+| Memory Limit           | 4 GB                 | 32 GB                    |
 | Swap                   | 1 GB                 | 1 GB                     |
 | Virtual Disk Limit     | 64 GB                | 256 GB                   |
 

--- a/docs/v0.6.0-alpha/core/deployment.en.mdx
+++ b/docs/v0.6.0-alpha/core/deployment.en.mdx
@@ -28,7 +28,7 @@ To achieve optimal performance, we strongly recommend configuring your Docker En
 | Docker Engine Resource | Minimal Requirements | Recommended Requirements |
 | :--------------------- | :------------------- | :----------------------- |
 | CPU Limit              | 2                    | 8                        |
-| Memory Limit           | 2 GB                 | 32 GB                    |
+| Memory Limit           | 4 GB                 | 32 GB                    |
 | Swap                   | 1 GB                 | 1 GB                     |
 | Virtual Disk Limit     | 64 GB                | 256 GB                   |
 

--- a/docs/v0.6.0-alpha/core/deployment.zh_CN.mdx
+++ b/docs/v0.6.0-alpha/core/deployment.zh_CN.mdx
@@ -28,7 +28,7 @@ To achieve optimal performance, we strongly recommend configuring your Docker En
 | Docker Engine Resource | Minimal Requirements | Recommended Requirements |
 | :--------------------- | :------------------- | :----------------------- |
 | CPU Limit              | 2                    | 8                        |
-| Memory Limit           | 2 GB                 | 32 GB                    |
+| Memory Limit           | 4 GB                 | 32 GB                    |
 | Swap                   | 1 GB                 | 1 GB                     |
 | Virtual Disk Limit     | 64 GB                | 256 GB                   |
 

--- a/docs/v0.8.0-beta/core/deployment.en.mdx
+++ b/docs/v0.8.0-beta/core/deployment.en.mdx
@@ -28,7 +28,7 @@ To achieve optimal performance, we strongly recommend configuring your Docker En
 | Docker Engine Resource | Minimal Requirements | Recommended Requirements |
 | :--------------------- | :------------------- | :----------------------- |
 | CPU Limit              | 2                    | 8                        |
-| Memory Limit           | 2 GB                 | 32 GB                    |
+| Memory Limit           | 4 GB                 | 32 GB                    |
 | Swap                   | 1 GB                 | 1 GB                     |
 | Virtual Disk Limit     | 64 GB                | 256 GB                   |
 

--- a/docs/v0.8.0-beta/core/deployment.zh_CN.mdx
+++ b/docs/v0.8.0-beta/core/deployment.zh_CN.mdx
@@ -28,7 +28,7 @@ To achieve optimal performance, we strongly recommend configuring your Docker En
 | Docker Engine Resource | Minimal Requirements | Recommended Requirements |
 | :--------------------- | :------------------- | :----------------------- |
 | CPU Limit              | 2                    | 8                        |
-| Memory Limit           | 2 GB                 | 32 GB                    |
+| Memory Limit           | 4 GB                 | 32 GB                    |
 | Swap                   | 1 GB                 | 1 GB                     |
 | Virtual Disk Limit     | 64 GB                | 256 GB                   |
 

--- a/docs/v0.9.0-beta/core/deployment.en.mdx
+++ b/docs/v0.9.0-beta/core/deployment.en.mdx
@@ -28,7 +28,7 @@ To achieve optimal performance, we strongly recommend configuring your Docker En
 | Docker Engine Resource | Minimal Requirements | Recommended Requirements |
 | :--------------------- | :------------------- | :----------------------- |
 | CPU Limit              | 2                    | 8                        |
-| Memory Limit           | 2 GB                 | 32 GB                    |
+| Memory Limit           | 4 GB                 | 32 GB                    |
 | Swap                   | 1 GB                 | 1 GB                     |
 | Virtual Disk Limit     | 64 GB                | 256 GB                   |
 

--- a/docs/v0.9.0-beta/core/deployment.zh_CN.mdx
+++ b/docs/v0.9.0-beta/core/deployment.zh_CN.mdx
@@ -28,7 +28,7 @@ To achieve optimal performance, we strongly recommend configuring your Docker En
 | Docker Engine Resource | Minimal Requirements | Recommended Requirements |
 | :--------------------- | :------------------- | :----------------------- |
 | CPU Limit              | 2                    | 8                        |
-| Memory Limit           | 2 GB                 | 32 GB                    |
+| Memory Limit           | 4 GB                 | 32 GB                    |
 | Swap                   | 1 GB                 | 1 GB                     |
 | Virtual Disk Limit     | 64 GB                | 256 GB                   |
 


### PR DESCRIPTION
Because

- Elasticsearch relies heavily on the Java heap space for storing and processing data. A minimum of 4GB RAM is required to launch the container.

This commit

- change the instruction accordingly.
