### PR TITLE
ci(github): add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @iamnamananand996 @EiffelFly


### PR DESCRIPTION
Because

- the `CODEOWNERS` file is missing in this repo

This commit

- add it and assign @iamnamananand996 and @EiffelFly as the owners
