### PR TITLE
fix: fix webpack-diff wrong pnpm version

### DIFF
--- a/.github/workflows/webpack-diff.yml
+++ b/.github/workflows/webpack-diff.yml
@@ -64,13 +64,13 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
 
       - uses: pnpm/action-setup@v2.0.1
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 7
+          version: 8
           run_install: false
 
       - name: Get pnpm store directory


### PR DESCRIPTION
Because

- fix webpack-diff wrong pnpm version

This commit

- fix webpack-diff wrong pnpm version
