### PR TITLE
docs(vdp): fix formatting convention for component names

### DIFF
--- a/docs/component/generic.en.mdx
+++ b/docs/component/generic.en.mdx
@@ -5,6 +5,6 @@ draft: false
 description: "Pre-built Generic components of the unstructured data ETL tool Instill Core https://github.com/instill-ai/instill-core"
 ---
 
-To support higher workflow complexity, a **Generic Component** is utilized for general pipeline tasks.
+To support higher workflow complexity, a **Generic** component is utilized for general pipeline tasks.
 This type of component enhances the overall pipeline by handling a variety of functions that are not specific to any single process,
 ensuring seamless integration and efficient operation within complex workflows.

--- a/docs/component/generic.zh_CN.mdx
+++ b/docs/component/generic.zh_CN.mdx
@@ -5,6 +5,6 @@ draft: false
 description: "Pre-built Generic components of the unstructured data ETL tool Instill Core https://github.com/instill-ai/instill-core"
 ---
 
-To support higher workflow complexity, a **Generic Component** is utilized for general pipeline tasks.
+To support higher workflow complexity, a **Generic** component is utilized for general pipeline tasks.
 This type of component enhances the overall pipeline by handling a variety of functions that are not specific to any single process,
 ensuring seamless integration and efficient operation within complex workflows.


### PR DESCRIPTION
Because

- We need to be consistent in formatting

This commit

- Corrects **Generic Component** to **Generic** component
