### PR TITLE
fix: correct broken link in the documentation

### DIFF
--- a/docs/vdp/clone.en.mdx
+++ b/docs/vdp/clone.en.mdx
@@ -10,7 +10,7 @@ Cloning another user's pipeline enables you to start with a proven framework, sa
 To clone another's pipeline on Instill Hub, follow these steps:
 
 1. Explore Instill Hub and locate a pipeline that interests you.
-2. **Initiate Cloning**: Click the `Clone` button located at the bottom of the pipeline. You can also clone from the Pipeline Preview Page if you accessed the pipeline through a shared link or after running it (learn how to run another user's pipeline [here](test)).
+2. **Initiate Cloning**: Click the `Clone` button located at the bottom of the pipeline. You can also clone from the Pipeline Preview Page if you accessed the pipeline through a shared link or after running it (learn how to run another user's pipeline [here](https://www.instill.tech/docs/vdp/run)).
 3. **Configure Settings**:
 
    - **Owner**: Select whether the cloned pipeline will be under your personal account or your organization's account.

--- a/docs/vdp/clone.zh-CN.mdx
+++ b/docs/vdp/clone.zh-CN.mdx
@@ -10,7 +10,7 @@ Cloning another user's pipeline enables you to start with a proven framework, sa
 To clone another's pipeline on Instill Hub, follow these steps:
 
 1. Navigate to Instill Hub and locate a pipeline that interests you.
-2. **Initiate Cloning**: Click the `Clone` button located at the bottom of the pipeline. You can also clone from the Pipeline Preview Page if you accessed the pipeline through a shared link or after running it (learn how to run another user's pipeline [here](test)).
+2. **Initiate Cloning**: Click the `Clone` button located at the bottom of the pipeline. You can also clone from the Pipeline Preview Page if you accessed the pipeline through a shared link or after running it (learn how to run another user's pipeline [here](https://www.instill.tech/docs/vdp/run)).
 3. **Configure Settings**:
 
    - **Owner**: Select whether the cloned pipeline will be under your personal account or your organization's account.


### PR DESCRIPTION
- Updated URL in /docs/vdp/clone.en.mdx to point to correct resource.
- Verified link is now accessible and directs to the intended page.

Refs: INS-4720

Because

- Link was broken

This commit

- Adds the correct link