### PR TITLE
fix(docs): repair broken links and update terminology

### DIFF
--- a/docs/core/concepts.en.mdx
+++ b/docs/core/concepts.en.mdx
@@ -31,7 +31,7 @@ The genuine protobuf documentation can be found in our [Buf Scheme Registry (BSR
 
 The foundation of Instill VDP lies in the concept of a **Pipeline**, which comprises connectors and operators, all defined within a `recipe`.
 A pipeline can be triggered using either SYNC APIs (for synchronous responses) or ASYNC APIs (ideal for long-running workloads).
-More detailed information about pipelines can be found in the [Pipeline](pipeline) section.
+More detailed information about pipelines can be found in the [Pipeline](../vdp/introduction) section.
 
 The implementation of the Pipeline concept is managed in the [pipeline-backend](https://github.com/instill-ai/pipeline-backend) repository.
 

--- a/docs/core/concepts.zh-CN.mdx
+++ b/docs/core/concepts.zh-CN.mdx
@@ -31,7 +31,7 @@ The genuine protobuf documentation can be found in our [Buf Scheme Registry (BSR
 
 The foundation of Instill VDP lies in the concept of a **Pipeline**, which comprises connectors and operators, all defined within a `recipe`.
 A pipeline can be triggered using either SYNC APIs (for synchronous responses) or ASYNC APIs (ideal for long-running workloads).
-More detailed information about pipelines can be found in the [Pipeline](pipeline) section.
+More detailed information about pipelines can be found in the [Pipeline](../vdp/introduction) section.
 
 The implementation of the Pipeline concept is managed in the [pipeline-backend](https://github.com/instill-ai/pipeline-backend) repository.
 

--- a/docs/quickstart.en.mdx
+++ b/docs/quickstart.en.mdx
@@ -294,4 +294,4 @@ To explore the available pre-deployed ML models for different AI tasks, navigate
 Each model in the Model Hub is designed to handle a specific [AI task](./model/ai-task).
 
 For detailed information about a specific model, click on its ID and review the Description and Setting sections.
-If you want to import the model into VDP, refer to the VDP documentation on the [Instill Model AI connector](./vdp/ai-connectors/instill-model).
+If you want to import the model into VDP, refer to the Instill Component documentation for the [Instill Model AI component](./component/ai/instill).

--- a/docs/quickstart.zh-CN.mdx
+++ b/docs/quickstart.zh-CN.mdx
@@ -294,4 +294,4 @@ To explore the available pre-deployed ML models for different AI tasks, navigate
 Each model in the Model Hub is designed to handle a specific [AI task](./model/ai-task).
 
 For detailed information about a specific model, click on its ID and review the Description and Setting sections.
-If you want to import the model into VDP, refer to the VDP documentation on the [Instill Model AI connector](./vdp/ai-connectors/instill-model).
+If you want to import the model into VDP, refer to the Instill Component documentation for the [Instill Model AI component](./component/ai/instill).


### PR DESCRIPTION
- Fixed broken Pipeline link on the Core Concepts page.
- Fixed broken final Instill Model AI Connector link on the Quickstart page.
- Updated terminology to reflect the shift from connectors to components.

Refs: INS-4726, INS-4724

Because

- I had detected a couple of broken links whilst conducting a review of the documentation (review still in progress - see INS-4730)

This commit

- Fixed broken links on Core Concepts and Quickstart pages, and updates terminology.
