### PR TITLE
docs(doc): apply emoji to instill projects

### DIFF
--- a/docs/core/deployment.en.mdx
+++ b/docs/core/deployment.en.mdx
@@ -27,7 +27,7 @@ To successfully launch Instill Core, it's essential to meet the following Docker
 Typically, launch failures occur due to inadequate virtual disk size.
 We strongly recommend configuring the Docker Engine with the following settings for optimal performance:
 
-In order to launch Instill Core successfully, it's imperative to ensure that your Docker Engine meets the following resource requirements.
+In order to launch **🔮 Instill Core** successfully, it's imperative to ensure that your Docker Engine meets the following resource requirements.
 Often, launch failures are attributed to insufficient virtual disk space.
 To achieve optimal performance, we strongly recommend configuring your Docker Engine with the following settings:
 
@@ -47,7 +47,7 @@ Please checkout [Instill CLI](./deployment/cli).
 
 ### Deploy with other methods
 
-Alternatively, you can deploy Instill Core via:
+Alternatively, you can deploy **🔮 Instill Core** via:
 
 - [Docker Compose](./deployment/docker-compose)
 - [Kubernetes using Helm](./deployment/kubernetes-using-helm)

--- a/docs/core/deployment.zh-CN.mdx
+++ b/docs/core/deployment.zh-CN.mdx
@@ -27,7 +27,7 @@ To successfully launch Instill Core, it's essential to meet the following Docker
 Typically, launch failures occur due to inadequate virtual disk size.
 We strongly recommend configuring the Docker Engine with the following settings for optimal performance:
 
-In order to launch Instill Core successfully, it's imperative to ensure that your Docker Engine meets the following resource requirements.
+In order to launch **🔮 Instill Core** successfully, it's imperative to ensure that your Docker Engine meets the following resource requirements.
 Often, launch failures are attributed to insufficient virtual disk space.
 To achieve optimal performance, we strongly recommend configuring your Docker Engine with the following settings:
 
@@ -47,7 +47,7 @@ Please checkout [Instill CLI](./deployment/cli).
 
 ### Deploy with other methods
 
-Alternatively, you can deploy Instill Core via:
+Alternatively, you can deploy **🔮 Instill Core** via:
 
 - [Docker Compose](./deployment/docker-compose)
 - [Kubernetes using Helm](./deployment/kubernetes-using-helm)

--- a/docs/core/deployment/cli.en.mdx
+++ b/docs/core/deployment/cli.en.mdx
@@ -1,31 +1,36 @@
 ---
-title: "Instill CLI"
+title: "⌨️ Instill CLI"
 lang: "en-US"
 draft: false
-description: "Learn about how to deploy Instill Core using Instill CLI"
+description: "Learn about Instill CLI, the command line tool, in the project Instill Core: https://github.com/instill-ai/instill-core"
 ---
 
-📺 [Instill CLI](https://github.com/instill-ai/cli) `inst` is the official command line for Instill Core and Instill Cloud.
+The command `inst` is the official command line tool for **🔮 Instill Core** and
+**☁️ Instill Cloud**.
 
 <ZoomableImg
   src="https://github.com/instill-ai/base/assets/141675602/52ce1eef-5169-4cbf-933d-9b37901a2c4f"
-  alt="Instill CLI"
+  alt="⌨️ Instill CLI - inst"
 />
 
 ## Prerequisites
 
 Make sure you have the prerequisites set up:
 
-- **macOS or Linux** - `inst` works on macOS or Linux, but does not support Windows at the moment.
-- **Docker and Docker Compose** - Instill Core uses Docker Compose to run all services at local. See the official [instructions](https://docs.docker.com/compose/install)
-  and the [Docker Resource Requirements for Instill Core](../deployment#docker-resource-requirements).
+- **macOS or Linux** - `inst` works on macOS or Linux, but does not support
+  Windows at the moment.
+- **Docker and Docker Compose** - **🔮 Instill Core** uses Docker Compose to run
+  all services at local. See the official
+  [instructions](https://docs.docker.com/compose/install) and the [Docker
+  Resource Requirements for Instill
+  Core](../deployment#docker-resource-requirements).
 
-<InfoBlock type="tip" title="tip">
-  When you use Instill CLI, you should add current user to docker group or use
-  in root.
+<InfoBlock type="tip" title="tip">  
+  When you use **⌨️ Instill CLI**, you should add current user to docker group or
+  use in root.
 </InfoBlock>
 
-## Downloading Instill CLI
+## Downloading ⌨️ Instill CLI
 
 `inst` is available via [Homebrew](https://brew.sh/).
 
@@ -40,7 +45,9 @@ brew upgrade inst
 
 </CH.Code>
 
-Alternatively, `inst` supports cross platforms. You can just download the Instill CLI for your operating system from [the Assets of the release page](https://github.com/instill-ai/cli/releases/latest):
+Alternatively, `inst` supports cross platforms. You can just download the **⌨️
+Instill CLI** for your operating system from [the Assets of the release
+page](https://github.com/instill-ai/cli/releases/latest):
 
 - MacOS x86_64/amd64
 - Linux x86_64/amd64
@@ -48,11 +55,13 @@ Alternatively, `inst` supports cross platforms. You can just download the Instil
 - Linux arm-v6
 - Windows x86_64/amd64
 
-If you do download from the above links, the steps are slightly different compared to downloading the ILLA CLI from Homebrew.
-After downloading the CLI, you will have to make it executable. Let’s take Instill CLI on MacOS for example:
+If you do download from the above links, the steps are slightly different
+compared to downloading the CLI from Homebrew. After downloading the CLI, you
+will have to make it executable. Let's take **⌨️ Instill CLI** on MacOS for
+example:
 
 ```shellscript
-## Download Instill CLI binary file from the latest release version.
+## Download **⌨️ Instill CLI** binary file from the latest release version.
 ## Here we use `v0.1.0-alpha` as example
 wget https://github.com/instill-ai/cli/releases/download/v0.1.0-alpha/inst_Darwin_x86_64.tar.gz
 
@@ -63,7 +72,7 @@ cd bin
 
 chmod +x inst
 
-## Run the Instill CLI
+## Run the ⌨️ Instill CLI
 ./inst
 ```
 
@@ -73,20 +82,22 @@ The following command will check all available commends:
 inst help
 ```
 
-## Deploying Instill Core
+## Deploying 🔮 Instill Core
 
-Once the Instill CLI has been installed, you can deploy a local Instill Core instance:
+Once the **⌨️ Instill CLI** has been installed, you can deploy a local **🔮
+Instill Core** instance:
 
 ```shellscript
 inst local deploy
 ```
 
-Once all services are up and running,the Console UI is ready to go at [http://localhost:3000](http://localhost:3000).
-Please proceed by following the [onboarding guide](../../quickstart#Authorisation).
+Once all services are up and running,the Console UI is ready to go at
+[http://localhost:3000](http://localhost:3000). Please proceed by following the
+[onboarding guide](../../quickstart#Authorisation).
 
-## Undeploy Instill Core
+## Undeploy 🔮 Instill Core
 
-To shutdown and clean up all Instill Core resources, run
+To shutdown and clean up all **🔮 Instill Core** resources, run
 
 ```shellscript
 inst local undeploy
@@ -103,9 +114,9 @@ inst auth login
 inst api vdp/v1beta/pipelines
 ```
 
-## Uninstall Instill CLI
+## Uninstall ⌨️ Instill CLI
 
-To uninstall Instill CLI:
+To uninstall **⌨️ Instill CLI**:
 
 ```shellscript
 brew uninstall inst

--- a/docs/core/deployment/cli.zh-CN.mdx
+++ b/docs/core/deployment/cli.zh-CN.mdx
@@ -1,31 +1,36 @@
 ---
-title: "Instill CLI"
-lang: "en-US"
+title: "⌨️ Instill CLI"
+lang: "zh-CN"
 draft: false
-description: "Learn about how to deploy Instill Core using Instill CLI"
+description: "Learn about Instill CLI, the command line tool, in the project Instill Core: https://github.com/instill-ai/instill-core"
 ---
 
-📺 [Instill CLI](https://github.com/instill-ai/cli) `inst` is the official command line for Instill Core and Instill Cloud.
+The command `inst` is the official command line tool for **🔮 Instill Core** and
+**☁️ Instill Cloud**.
 
 <ZoomableImg
   src="https://github.com/instill-ai/base/assets/141675602/52ce1eef-5169-4cbf-933d-9b37901a2c4f"
-  alt="Instill CLI"
+  alt="⌨️ Instill CLI - inst"
 />
 
 ## Prerequisites
 
 Make sure you have the prerequisites set up:
 
-- **macOS or Linux** - `inst` works on macOS or Linux, but does not support Windows at the moment.
-- **Docker and Docker Compose** - Instill Core uses Docker Compose to run all services at local. See the official [instructions](https://docs.docker.com/compose/install)
-  and the [Docker Resource Requirements for Instill Core](../deployment#docker-resource-requirements).
+- **macOS or Linux** - `inst` works on macOS or Linux, but does not support
+  Windows at the moment.
+- **Docker and Docker Compose** - **🔮 Instill Core** uses Docker Compose to run
+  all services at local. See the official
+  [instructions](https://docs.docker.com/compose/install) and the [Docker
+  Resource Requirements for Instill
+  Core](../deployment#docker-resource-requirements).
 
 <InfoBlock type="tip" title="tip">
-  When you use Instill CLI, you should add current user to docker group or use
-  in root.
+  When you use **⌨️ Instill CLI**, you should add current user to docker group or
+  use in root.
 </InfoBlock>
 
-## Downloading Instill CLI
+## Downloading ⌨️ Instill CLI
 
 `inst` is available via [Homebrew](https://brew.sh/).
 
@@ -40,7 +45,9 @@ brew upgrade inst
 
 </CH.Code>
 
-Alternatively, `inst` supports cross platforms. You can just download the Instill CLI for your operating system from [the Assets of the release page](https://github.com/instill-ai/cli/releases/latest):
+Alternatively, `inst` supports cross platforms. You can just download the **⌨️
+Instill CLI** for your operating system from [the Assets of the release
+page](https://github.com/instill-ai/cli/releases/latest):
 
 - MacOS x86_64/amd64
 - Linux x86_64/amd64
@@ -48,11 +55,13 @@ Alternatively, `inst` supports cross platforms. You can just download the Instil
 - Linux arm-v6
 - Windows x86_64/amd64
 
-If you do download from the above links, the steps are slightly different compared to downloading the ILLA CLI from Homebrew.
-After downloading the CLI, you will have to make it executable. Let’s take Instill CLI on MacOS for example:
+If you do download from the above links, the steps are slightly different
+compared to downloading the CLI from Homebrew. After downloading the CLI, you
+will have to make it executable. Let's take **⌨️ Instill CLI** on MacOS for
+example:
 
 ```shellscript
-## Download Instill CLI binary file from the latest release version.
+## Download **⌨️ Instill CLI** binary file from the latest release version.
 ## Here we use `v0.1.0-alpha` as example
 wget https://github.com/instill-ai/cli/releases/download/v0.1.0-alpha/inst_Darwin_x86_64.tar.gz
 
@@ -63,7 +72,7 @@ cd bin
 
 chmod +x inst
 
-## Run the Instill CLI
+## Run the ⌨️ Instill CLI
 ./inst
 ```
 
@@ -73,20 +82,22 @@ The following command will check all available commends:
 inst help
 ```
 
-## Deploying Instill Core
+## Deploying 🔮 Instill Core
 
-Once the Instill CLI has been installed, you can deploy a local Instill Core instance:
+Once the **⌨️ Instill CLI** has been installed, you can deploy a local **🔮
+Instill Core** instance:
 
 ```shellscript
 inst local deploy
 ```
 
-Once all services are up and running,the Console UI is ready to go at [http://localhost:3000](http://localhost:3000).
-Please proceed by following the [onboarding guide](../../quickstart#Authorisation).
+Once all services are up and running,the Console UI is ready to go at
+[http://localhost:3000](http://localhost:3000). Please proceed by following the
+[onboarding guide](../../quickstart#Authorisation).
 
-## Undeploy Instill Core
+## Undeploy 🔮 Instill Core
 
-To shutdown and clean up all Instill Core resources, run
+To shutdown and clean up all **🔮 Instill Core** resources, run
 
 ```shellscript
 inst local undeploy
@@ -103,9 +114,9 @@ inst auth login
 inst api vdp/v1beta/pipelines
 ```
 
-## Uninstall Instill CLI
+## Uninstall ⌨️ Instill CLI
 
-To uninstall Instill CLI:
+To uninstall **⌨️ Instill CLI**:
 
 ```shellscript
 brew uninstall inst

--- a/docs/core/deployment/docker-compose.en.mdx
+++ b/docs/core/deployment/docker-compose.en.mdx
@@ -5,47 +5,50 @@ draft: false
 description: "Learn about how to deploy Instill Core using Docker Compose"
 ---
 
-Docker Compose is the a straightforward way to set up Instill Core in local machines or remote instances.
+Docker Compose is the a straightforward way to set up **🔮 Instill Core** in
+local machines or remote instances.
 
 <InfoBlock type="info" title="info">
-  Instructions on this page have been tested on macOS and Ubuntu 22.04.
-  Nevertheless, we strongly recommend using our auto-deployment tool, [Instill
-  CLI](cli), for the deployment process.
+  Instructions on this page have been tested on macOS and Ubuntu 22.04.  
 </InfoBlock>
 
 ## Prerequisites
 
 Make sure you have the prerequisites set up:
 
-- **macOS or Linux** - Instill Core works on macOS or Linux, but does not support Windows at the moment.
-- **Docker and Docker Compose** - Instill Core uses Docker Compose to run all services at local. See the official [instructions](https://docs.docker.com/compose/install)
-  and the [Docker Resource Requirements for Instill Core](../deployment#docker-resource-requirements).
+- **macOS or Linux** - **🔮 Instill Core** works on macOS or Linux, but does not
+  support Windows at the moment.
+- **Docker and Docker Compose** - **🔮 Instill Core** uses Docker Compose to run
+  all services at local. See the official
+  [instructions](https://docs.docker.com/compose/install) and the [Docker
+  Resource Requirements](../deployment#docker-resource-requirements).
 
 ## Setup
 
-<InfoBlock type="warning" title="WARNING">
-  The code in the `main` branch reflects ongoing development progress for the
-  next release and may not work as expected. If you need a stable alpha version,
-  use the [latest release](https://github.com/instill-ai/base/releases) instead.
+<InfoBlock type="warning" title="warning">
+  {" "}
+  The code in the `main` branch reflects ongoing development progress for the next
+  release and may not work as expected. If you need a stable alpha version, use the
+  [latest release](https://github.com/instill-ai/base/releases) instead.{" "}
 </InfoBlock>
 
 On your workstation, run:
 
 <VersionCore>
-```shellscript
-git clone -b -version- https://github.com/instill-ai/instill-core.git && cd instill-core 
-make all 
-```
+  ```bash 
+  git clone -b -version-
+  https://github.com/instill-ai/instill-core.git && cd instill-core make all
+  ```
 </VersionCore>
 
-
-Once all services are up and running,the Console UI is ready to go at [http://localhost:3000](http://localhost:3000).
-Proceed by following the [authorisation guide](../../quickstart#Authorisation).
+Once all services are up and running,the Console UI is ready to go at
+[http://localhost:3000](http://localhost:3000). Proceed by following the
+[authorisation guide](../../quickstart#Authorisation).
 
 ## Shutdown
 
-To shutdown and clean up all Instill Core resources, run
+To shutdown and clean up all **🔮 Instill Core** resources, run
 
-```shellscript
+```bash
 make down
 ```

--- a/docs/core/deployment/docker-compose.zh-CN.mdx
+++ b/docs/core/deployment/docker-compose.zh-CN.mdx
@@ -1,50 +1,54 @@
 ---
 title: "Docker Compose"
-lang: "en-US"
+lang: "zh-CN"
 draft: false
 description: "Learn about how to deploy Instill Core using Docker Compose"
 ---
 
-Docker Compose is the a straightforward way to set up Instill Core in local machines or remote instances.
+Docker Compose is the a straightforward way to set up **🔮 Instill Core** in
+local machines or remote instances.
 
 <InfoBlock type="info" title="info">
-  Instructions on this page have been tested on macOS and Ubuntu 22.04.
-  Nevertheless, we strongly recommend using our auto-deployment tool, [Instill
-  CLI](cli), for the deployment process.
+  Instructions on this page have been tested on macOS and Ubuntu 22.04.  
 </InfoBlock>
 
 ## Prerequisites
 
 Make sure you have the prerequisites set up:
 
-- **macOS or Linux** - Instill Core works on macOS or Linux, but does not support Windows at the moment.
-- **Docker and Docker Compose** - Instill Core uses Docker Compose to run all services at local. See the official [instructions](https://docs.docker.com/compose/install)
-  and the [Docker Resource Requirements for Instill Core](../deployment#docker-resource-requirements).
+- **macOS or Linux** - **🔮 Instill Core** works on macOS or Linux, but does not
+  support Windows at the moment.
+- **Docker and Docker Compose** - **🔮 Instill Core** uses Docker Compose to run
+  all services at local. See the official
+  [instructions](https://docs.docker.com/compose/install) and the [Docker
+  Resource Requirements](../deployment#docker-resource-requirements).
 
 ## Setup
 
-<InfoBlock type="warning" title="WARNING">
-  The code in the `main` branch reflects ongoing development progress for the
-  next release and may not work as expected. If you need a stable alpha version,
-  use the [latest release](https://github.com/instill-ai/base/releases) instead.
+<InfoBlock type="warning" title="warning">
+  {" "}
+  The code in the `main` branch reflects ongoing development progress for the next
+  release and may not work as expected. If you need a stable alpha version, use the
+  [latest release](https://github.com/instill-ai/base/releases) instead.{" "}
 </InfoBlock>
 
 On your workstation, run:
 
 <VersionCore>
-```shellscript
-git clone -b -version- https://github.com/instill-ai/instill-core.git && cd instill-core
-make all
-```
+  ```bash 
+  git clone -b -version-
+  https://github.com/instill-ai/instill-core.git && cd instill-core make all
+  ```
 </VersionCore>
 
-Once all services are up and running,the Console UI is ready to go at [http://localhost:3000](http://localhost:3000).
-Proceed by following the [authorisation guide](../../quickstart#Authorisation).
+Once all services are up and running,the Console UI is ready to go at
+[http://localhost:3000](http://localhost:3000). Proceed by following the
+[authorisation guide](../../quickstart#Authorisation).
 
 ## Shutdown
 
-To shutdown and clean up all Instill Core resources, run
+To shutdown and clean up all **🔮 Instill Core** resources, run
 
-```shellscript
+```bash
 make down
 ```

--- a/docs/core/deployment/kubernetes-using-helm.en.mdx
+++ b/docs/core/deployment/kubernetes-using-helm.en.mdx
@@ -5,7 +5,7 @@ draft: false
 description: "Learn about how to deploy Instill Core in Kubernetes using Helm"
 ---
 
-Kubernetes offers an elastic way of managing Instill Core to persist the services and scale resources horizontally and vertically.
+Kubernetes offers an elastic way of managing **🔮 Instill Core** to persist the services and scale resources horizontally and vertically.
 
 ## Setup
 
@@ -62,13 +62,13 @@ instill-ai/core 	<chart-version> <app-version> 	The Helm chart of Instill Core
 ```
 
 <InfoBlock type="info" title="info">
-  Instill Core and its Helm chart are still in a pre-release Alpha version, so
+  **🔮 Instill Core** and its Helm chart are still in a pre-release Alpha version, so
   the `--devel` flag is necessary for the access of Helm charts.
 </InfoBlock>
 
 ## Install
 
-Install the Instill Core chart:
+Install the **🔮 Instill Core** chart:
 
 ```bash
 helm install core instill-ai/core --devel --namespace instill-ai --create-namespace --set tags.prometheusStack=true
@@ -108,7 +108,7 @@ To uninstall the chart:
 helm uninstall core --namespace instill-ai
 ```
 
-and clean up all Instill Core related persistent volumes:
+and clean up all **🔮 Instill Core** related persistent volumes:
 
 ```bash
 kubectl delete pvc --all -n instill-ai

--- a/docs/core/deployment/kubernetes-using-helm.zh-CN.mdx
+++ b/docs/core/deployment/kubernetes-using-helm.zh-CN.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Kubernetes Using Helm"
-lang: "en-US"
+lang: "zh-CN"
 draft: false
 description: "Learn about how to deploy Instill Core in Kubernetes using Helm"
 ---
 
-Kubernetes offers an elastic way of managing Instill Core to persist the services and scale resources horizontally and vertically.
+Kubernetes offers an elastic way of managing **🔮 Instill Core** to persist the services and scale resources horizontally and vertically.
 
 ## Setup
 
@@ -62,13 +62,13 @@ instill-ai/core 	<chart-version> <app-version> 	The Helm chart of Instill Core
 ```
 
 <InfoBlock type="info" title="info">
-  Instill Core and its Helm chart are still in a pre-release Alpha version, so
-  the `--devel` flag is necessary for the access of Helm charts.
+  **🔮 Instill Core** and its Helm chart are still in a pre-release Alpha
+  version, so the `--devel` flag is necessary for the access of Helm charts.
 </InfoBlock>
 
 ## Install
 
-Install the Instill Core chart:
+Install the **🔮 Instill Core** chart:
 
 ```bash
 helm install core instill-ai/core --devel --namespace instill-ai --create-namespace --set tags.prometheusStack=true
@@ -108,7 +108,7 @@ To uninstall the chart:
 helm uninstall core --namespace instill-ai
 ```
 
-and clean up all Instill Core related persistent volumes:
+and clean up all **🔮 Instill Core** related persistent volumes:
 
 ```bash
 kubectl delete pvc --all -n instill-ai

--- a/docs/model/prepare.en.mdx
+++ b/docs/model/prepare.en.mdx
@@ -43,7 +43,7 @@ In the `instill.yaml` file, you are can specify the following details:
 - **repo**:
   - Required: `string`
   - Format: `USER_ID/MODEL_ID`
-  - Description: Your Instill Core namespace.
+  - Description: The namespace.
 
 Below is an example config file for a `TinyLlama` model designed to utilize GPU
 resources:

--- a/docs/model/prepare.zh-CN.mdx
+++ b/docs/model/prepare.zh-CN.mdx
@@ -43,7 +43,7 @@ In the `instill.yaml` file, you are can specify the following details:
 - **repo**:
   - Required: `string`
   - Format: `USER_ID/MODEL_ID`
-  - Description: Your Instill Core namespace.
+  - Description: The namespace.
 
 Below is an example config file for a `TinyLlama` model designed to utilize GPU
 resources:

--- a/docs/welcome.en.mdx
+++ b/docs/welcome.en.mdx
@@ -56,7 +56,7 @@ pipelines, enhancing **💧 Instill VDP** and unlocking limitless possibilities.
 Not quite into self-hosting? We've got you covered with **☁️ [Instill
 Cloud](https://instill.tech/?utm_source=documentation&utm_medium=link)**. It's a
 fully managed public cloud service, providing you with access to all the
-features of 🔮 Instill Core without the burden of infrastructure management. All
+features of **🔮 Instill Core** without the burden of infrastructure management. All
 you need to do is to one-click sign up to start building your AI-first
 applications.
 
@@ -78,7 +78,7 @@ applications.
   experience
 - ⚡️ Leverage high-performing Go backends
 - 📊 Monitor pipeline performance with a detailed dashboard
-- 🤠 Access no-/low-code interfaces, making 🔮 Instill Core suitable for all AI
+- 🤠 Access no-/low-code interfaces, making **🔮 Instill Core** suitable for all AI
   and data practitioners
 
 ## Client Access
@@ -111,7 +111,7 @@ with fellow users and seek assistance:
 
 ## Learn More and Stay Connected
 
-- ⭐️ Show your support for Instill Core by giving it a star on
+- ⭐️ Show your support for **🔮 Instill Core** by giving it a star on
   [GitHub](https://github.com/instill-ai)
 - 📚 Read our insightful [blog](/blog/?utm_source=documentation&utm_medium=link)
   and [tutorials](/tutorials/?utm_source=documentation&utm_medium=link)

--- a/docs/welcome.zh-CN.mdx
+++ b/docs/welcome.zh-CN.mdx
@@ -56,7 +56,7 @@ pipelines, enhancing **💧 Instill VDP** and unlocking limitless possibilities.
 Not quite into self-hosting? We've got you covered with **☁️ [Instill
 Cloud](https://instill.tech/?utm_source=documentation&utm_medium=link)**. It's a
 fully managed public cloud service, providing you with access to all the
-features of 🔮 Instill Core without the burden of infrastructure management. All
+features of **🔮 Instill Core** without the burden of infrastructure management. All
 you need to do is to one-click sign up to start building your AI-first
 applications.
 
@@ -78,7 +78,7 @@ applications.
   experience
 - ⚡️ Leverage high-performing Go backends
 - 📊 Monitor pipeline performance with a detailed dashboard
-- 🤠 Access no-/low-code interfaces, making 🔮 Instill Core suitable for all AI
+- 🤠 Access no-/low-code interfaces, making **🔮 Instill Core** suitable for all AI
   and data practitioners
 
 ## Client Access
@@ -111,7 +111,7 @@ with fellow users and seek assistance:
 
 ## Learn More and Stay Connected
 
-- ⭐️ Show your support for Instill Core by giving it a star on
+- ⭐️ Show your support for **🔮 Instill Core** by giving it a star on
   [GitHub](https://github.com/instill-ai)
 - 📚 Read our insightful [blog](/blog/?utm_source=documentation&utm_medium=link)
   and [tutorials](/tutorials/?utm_source=documentation&utm_medium=link)


### PR DESCRIPTION
Because

- to make the projects in the documentation more visually distinguishable, we have assigned emoji to each project as
  - ☁️ Instill Cloud
  - 🔮 Instill Core
  - 💧 Instill VDP
  - ⚗️ Instill Model
  - 💾 Instill Artifact
  - ⚙️ Instill Component
  - 📺 Instill Console
  - ⌨️ Instill CLI 
  - 📦 Instill SDK

This commit

- add missed emoji in the docs
