### PR TITLE
docs(vdp): fix VDP acronym

### DIFF
--- a/docs/vdp/introduction.en.mdx
+++ b/docs/vdp/introduction.en.mdx
@@ -7,7 +7,7 @@ description: "Build end-to-end unstructured data pipelines with the full-stack A
 
 ## About the Project
 
-**💧 Instill VDP** (Visual Data Pipeline) is a powerful tool designed to build
+**💧 Instill VDP** (Versatile Data Pipeline) is a powerful tool designed to build
 end-to-end unstructured data pipelines. It leverages the capabilities of
 3rd-party data, AI, and applications functionalities and seamlessly connect with
 **⚗️ [Instill Model](/docs/model/introduction)** and **💾 [Instill

--- a/docs/vdp/introduction.zh-CN.mdx
+++ b/docs/vdp/introduction.zh-CN.mdx
@@ -7,7 +7,7 @@ description: "Build end-to-end unstructured data pipelines with the full-stack A
 
 ## About the Project
 
-**💧 Instill VDP** (Visual Data Pipeline) is a powerful tool designed to build
+**💧 Instill VDP** (Versatile Data Pipeline) is a powerful tool designed to build
 end-to-end unstructured data pipelines. It leverages the capabilities of
 3rd-party data, AI, and applications functionalities and seamlessly connect with
 **⚗️ [Instill Model](/docs/model/introduction)** and **💾 [Instill


### PR DESCRIPTION
Because

- VDP was incorrectly referred to as Visual Data Pipeline

This commit

- Corrects this
