### PR TITLE
docs(model): fix inconsistencies

### DIFF
--- a/docs/model/create.en.mdx
+++ b/docs/model/create.en.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Create a Model"
+title: "Create Model"
 lang: "en-US"
 draft: false
 description: "Learn about Instill Model, the MLOps/LLMOps platform, in the project Instill Core: https://github.com/instill-ai/instill-core"
@@ -7,7 +7,7 @@ description: "Learn about Instill Model, the MLOps/LLMOps platform, in the proje
 
 To create a model resource in **⚗️ Instill Model**, adhere to the following steps:
 
-1. Initiate by selecting `Create A Model` on your model page.
+1. Initiate by selecting `+ Create Model` on your model page.
 2. Configure
    - **Owner**: Determine whether the model will reside under your personal account or
      your organization's account.

--- a/docs/model/state.en.mdx
+++ b/docs/model/state.en.mdx
@@ -18,4 +18,4 @@ A deployed model version can be in these states:
 If deployment fails, the version will be in the `ERROR` state.
 
 If the model does not receive any requests for 30 minutes a scale-down will be
-triggered, and if the replica cound falls to `0`, the model will go `OFFLINE`.
+triggered, and if the replica count falls to `0`, the model will go `OFFLINE`.

--- a/docs/model/state.zh-CN.mdx
+++ b/docs/model/state.zh-CN.mdx
@@ -18,4 +18,4 @@ A deployed model version can be in these states:
 If deployment fails, the version will be in the `ERROR` state.
 
 If the model does not receive any requests for 30 minutes a scale-down will be
-triggered, and if the replica cound falls to `0`, the model will go `OFFLINE`.
+triggered, and if the replica count falls to `0`, the model will go `OFFLINE`.


### PR DESCRIPTION
Because

- there was a typo

This commit

- fixes typo
