### PR TITLE
feat: document Instill Credit purchase

### DIFF
--- a/docs/cloud/credit.en.mdx
+++ b/docs/cloud/credit.en.mdx
@@ -125,12 +125,12 @@ The amount of monthly **Instill Credit** of a user or organization depends on th
 [subscription plan](https://www.instill.tech/pricing).
 
 Additionally, subscribers can purchase extra credit in case the monthly amount
-doesn't cover their **Instill Credit** needs. Purchase credit in contrast to
-monthly credit, won't expire at the end of the billing cycle. For that reason,
+doesn't cover their **Instill Credit** needs. In contrast to monthly credit, 
+purchase credit won't expire at the end of the billing cycle. For that reason,
 purchased credit will only be consumed only when the subscription credit has
 been exhausted.
 
 Our roadmap includes more features to cover more complex **Instill Credit** use
-cases, such as **Credit auto-billing**, where credit is topped up before it is
+cases, such as **Credit Auto-billing**, where credit is topped up before it is
 totally exhausted, keeping production environments safe from any potential
 downtime.

--- a/docs/cloud/credit.en.mdx
+++ b/docs/cloud/credit.en.mdx
@@ -124,10 +124,13 @@ personal **Instill Credit** will be consumed during the operation.
 The amount of monthly **Instill Credit** of a user or organization depends on their
 [subscription plan](https://www.instill.tech/pricing).
 
-Our roadmap includes features to cover the cases when the monthly **Instill Credit**
-isn't enough:
+Additionally, subscribers can purchase extra credit in case the monthly amount
+doesn't cover their **Instill Credit** needs. Purchase credit in contrast to
+monthly credit, won't expire at the end of the billing cycle. For that reason,
+purchased credit will only be consumed only when the subscription credit has
+been exhausted.
 
-- **Credit purchase**, for users that exhausted their credit before the end of
-  the month.
-- **Credit auto-billing**, which will top-up credit before it is exhausted,
-  keeping production environment from any potential downtime.
+Our roadmap includes more features to cover more complex **Instill Credit** use
+cases, such as **Credit auto-billing**, where credit is topped up before it is
+totally exhausted, keeping production environments safe from any potential
+downtime.

--- a/docs/cloud/credit.zh-CN.mdx
+++ b/docs/cloud/credit.zh-CN.mdx
@@ -125,12 +125,12 @@ The amount of monthly **Instill Credit** of a user or organization depends on th
 [subscription plan](https://www.instill.tech/pricing).
 
 Additionally, subscribers can purchase extra credit in case the monthly amount
-doesn't cover their **Instill Credit** needs. Purchase credit in contrast to
-monthly credit, won't expire at the end of the billing cycle. For that reason,
+doesn't cover their **Instill Credit** needs. In contrast to monthly credit, 
+purchase credit won't expire at the end of the billing cycle. For that reason,
 purchased credit will only be consumed only when the subscription credit has
 been exhausted.
 
 Our roadmap includes more features to cover more complex **Instill Credit** use
-cases, such as **Credit auto-billing**, where credit is topped up before it is
+cases, such as **Credit Auto-billing**, where credit is topped up before it is
 totally exhausted, keeping production environments safe from any potential
 downtime.

--- a/docs/cloud/credit.zh-CN.mdx
+++ b/docs/cloud/credit.zh-CN.mdx
@@ -124,10 +124,13 @@ personal **Instill Credit** will be consumed during the operation.
 The amount of monthly **Instill Credit** of a user or organization depends on their
 [subscription plan](https://www.instill.tech/pricing).
 
-Our roadmap includes features to cover the cases when the monthly **Instill Credit**
-isn't enough:
+Additionally, subscribers can purchase extra credit in case the monthly amount
+doesn't cover their **Instill Credit** needs. Purchase credit in contrast to
+monthly credit, won't expire at the end of the billing cycle. For that reason,
+purchased credit will only be consumed only when the subscription credit has
+been exhausted.
 
-- **Credit purchase**, for users that exhausted their credit before the end of
-  the month.
-- **Credit auto-billing**, which will top-up credit before it is exhausted,
-  keeping production environment from any potential downtime.
+Our roadmap includes more features to cover more complex **Instill Credit** use
+cases, such as **Credit auto-billing**, where credit is topped up before it is
+totally exhausted, keeping production environments safe from any potential
+downtime.


### PR DESCRIPTION
Because

- Credit purchase is marked as an upcoming feature but it will be included in the next release.

This commit

- Updates the documentation about subscription vs purchased Instill Credit.

![CleanShot 2024-06-19 at 13 18 46](https://github.com/instill-ai/instill.tech/assets/3977183/527a2164-8fe4-4b34-bca1-43450c0d0ca0)
