### PR TITLE
docs: remove out-of-date gifs from quickstart

### DIFF
--- a/docs/quickstart.en.mdx
+++ b/docs/quickstart.en.mdx
@@ -48,15 +48,10 @@ Instill AI team.
 Congratulations 🎉 you have successfully run your first **💧 Instill VDP**
 pipeline!
 
-As you can see, this pipeline generates stickers based on the text prompt you
-provide. The **📺 Instill Console** window on the left side of the screen
-displays all of the components within this pipeline, and how they are connected.
-You can inspect them by using the `+` icons to expand them.
-
-<ZoomableImg
-  src="/docs-assets/core/inspect-components.gif"
-  alt="Inspecting the Pipeline"
-/>
+This pipeline generates stickers based on the text prompt you provide. The **📺
+Instill Console** window on the left side of the screen displays all of the
+components within this pipeline, and how they are connected. You can inspect
+them by using the `+` icons to expand them.
 
 From this you can see how the pipeline takes an initial text prompt from the
 user, enhances the prompt to be more descriptive using the Llama3-8b-Instruct
@@ -83,11 +78,6 @@ public pipeline to suit your own requirements, you simply need to clone it.
 2. Specify a name for the pipeline and provide a short description.
 3. Ensure the pipeline has the desired visibility.
 4. Click the `Clone` button.
-
-<ZoomableImg
-  src="/docs-assets/core/clone.gif"
-  alt="Cloning the Pipeline"
-/>
 
 ### Step 2. Edit with 📺 Instill Console
 

--- a/docs/quickstart.zh-CN.mdx
+++ b/docs/quickstart.zh-CN.mdx
@@ -48,15 +48,10 @@ Instill AI team.
 Congratulations 🎉 you have successfully run your first **💧 Instill VDP**
 pipeline!
 
-As you can see, this pipeline generates stickers based on the text prompt you
-provide. The **📺 Instill Console** window on the left side of the screen
-displays all of the components within this pipeline, and how they are connected.
-You can inspect them by using the `+` icons to expand them.
-
-<ZoomableImg
-  src="/docs-assets/core/inspect-components.gif"
-  alt="Inspecting the Pipeline"
-/>
+This pipeline generates stickers based on the text prompt you provide. The **📺
+Instill Console** window on the left side of the screen displays all of the
+components within this pipeline, and how they are connected. You can inspect
+them by using the `+` icons to expand them.
 
 From this you can see how the pipeline takes an initial text prompt from the
 user, enhances the prompt to be more descriptive using the Llama3-8b-Instruct
@@ -83,11 +78,6 @@ public pipeline to suit your own requirements, you simply need to clone it.
 2. Specify a name for the pipeline and provide a short description.
 3. Ensure the pipeline has the desired visibility.
 4. Click the `Clone` button.
-
-<ZoomableImg
-  src="/docs-assets/core/clone.gif"
-  alt="Cloning the Pipeline"
-/>
 
 ### Step 2. Edit with 📺 Instill Console
 


### PR DESCRIPTION
Because

- Some gifs show out-of-date UI

This commit

- Removes out-of-date gifs from quickstart
