### PR TITLE
chore: doc for anthropic token to instill credit

### DIFF
--- a/docs/cloud/credit.en.mdx
+++ b/docs/cloud/credit.en.mdx
@@ -59,14 +59,18 @@ Credit** cost per unit.
 
 #### LLM
 
-| Vendor | Model        | Credit Cost per 1,000 Input Tokens | Credit Cost per 1,000 Output Tokens |
-| :----- | :----------- | :--------------------------------- | :---------------------------------- |
-| OpenAI | GPT-3.5      | 5                                  | 15                                  |
-| OpenAI | GPT-4        | 300                                | 600                                 |
-| OpenAI | GPT-4 (32K)  | 600                                | 1,200                               |
-| OpenAI | GPT-4 (128K) | 100                                | 300                                 |
-| OpenAI | GPT-4 VISION | 100                                | 300                                 |
-| OpenAI | GPT-4o       | 50                                 | 150                                 |
+| Vendor    | Model             | Credit Cost per 1,000 Input Tokens | Credit Cost per 1,000 Output Tokens |
+| :-------- | :---------------- | :--------------------------------- | :---------------------------------- |
+| OpenAI    | GPT-3.5           | 5                                  | 15                                  |
+| OpenAI    | GPT-4             | 300                                | 600                                 |
+| OpenAI    | GPT-4 (32K)       | 600                                | 1,200                               |
+| OpenAI    | GPT-4 (128K)      | 100                                | 300                                 |
+| OpenAI    | GPT-4 VISION      | 100                                | 300                                 |
+| OpenAI    | GPT-4o            | 50                                 | 150                                 |
+| Anthropic | Claude 3.5 Sonnet | 30                                 | 150                                 |
+| Anthropic | Claude 3 Opus     | 150                                | 750                                 |
+| Anthropic | Claude 3 Sonnet   | 30                                 | 150                                 |
+| Anthropic | Claude 3 Haiku    | 2.5                                | 15                                  |
 
 #### Text Embeddings
 

--- a/docs/cloud/credit.zh-CN.mdx
+++ b/docs/cloud/credit.zh-CN.mdx
@@ -59,14 +59,18 @@ Credit** cost per unit.
 
 #### LLM
 
-| Vendor | Model        | Credit Cost per 1,000 Input Tokens | Credit Cost per 1,000 Output Tokens |
-| :----- | :----------- | :--------------------------------- | :---------------------------------- |
-| OpenAI | GPT-3.5      | 5                                  | 15                                  |
-| OpenAI | GPT-4        | 300                                | 600                                 |
-| OpenAI | GPT-4 (32K)  | 600                                | 1,200                               |
-| OpenAI | GPT-4 (128K) | 100                                | 300                                 |
-| OpenAI | GPT-4 VISION | 100                                | 300                                 |
-| OpenAI | GPT-4o       | 50                                 | 150                                 |
+| Vendor    | Model             | Credit Cost per 1,000 Input Tokens | Credit Cost per 1,000 Output Tokens |
+| :-------- | :---------------- | :--------------------------------- | :---------------------------------- |
+| OpenAI    | GPT-3.5           | 5                                  | 15                                  |
+| OpenAI    | GPT-4             | 300                                | 600                                 |
+| OpenAI    | GPT-4 (32K)       | 600                                | 1,200                               |
+| OpenAI    | GPT-4 (128K)      | 100                                | 300                                 |
+| OpenAI    | GPT-4 VISION      | 100                                | 300                                 |
+| OpenAI    | GPT-4o            | 50                                 | 150                                 |
+| Anthropic | Claude 3.5 Sonnet | 30                                 | 150                                 |
+| Anthropic | Claude 3 Opus     | 150                                | 750                                 |
+| Anthropic | Claude 3 Sonnet   | 30                                 | 150                                 |
+| Anthropic | Claude 3 Haiku    | 2.5                                | 15                                  |
 
 #### Text Embeddings
 


### PR DESCRIPTION
Because

- users can use anthropic with instill credit

This commit

- add doc about the transformation between the token and instill credit 
